### PR TITLE
Explore disk streaming for large CRDT data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -937,6 +937,55 @@ pcrdt.snapshot()?;
 - Old (10 full snapshots): 151 MB
 - New (1 full + 9 incrementals): 6 MB (95% reduction)
 
+## Disk-Streaming CRDT (Rust)
+
+The Rust implementation includes a disk-streaming variant (`src/persist/streaming.rs`) for datasets larger than memory. It provides the same API as `PersistedCRDT` but loads records on-demand from indexed snapshots.
+
+### Architecture
+
+Three-tier memory hierarchy:
+
+1. **Hot Tier (Memory)** — Recent writes, always in memory. A full in-memory `CRDT` instance.
+2. **LRU Cache (Memory)** — Frequently accessed cold records (configurable, default 1000 records).
+3. **Indexed Snapshot (Disk)** — All records, loaded on-demand via index lookups.
+
+At startup, only the index and tombstones are loaded (not all records). Records are fetched from disk as needed.
+
+### Indexed Snapshot Format
+
+Binary format with four sections:
+- **Header**: magic (`CRDS`), version, node_id, clock_value, record/tombstone counts, section offsets
+- **Records**: MessagePack-serialized records, each at a seekable offset
+- **Tombstones**: Full `HashMap<K, TombstoneInfo>`, loaded at startup (typically small)
+- **Index**: `Vec<IndexEntry { key, offset, length }>`, loaded at startup for O(1) key-to-offset lookups
+
+### Key Design Decisions
+
+- **Hot/cold merge on snapshot**: `create_indexed_snapshot()` merges hot records over cold, clears the hot tier, rotates WAL.
+- **Cold record loading**: Operations that need a cold record (e.g., `merge_changes`, `delete_record`) load it into hot via `insert_record_direct` before modifying.
+- **Tombstone tracking**: `hot_keys` and `hot_tombstones` track which keys have been touched in the hot tier, used during snapshot merge to decide precedence.
+- **Auto-migration**: Existing MessagePack snapshots from `PersistedCRDT` are auto-converted to indexed format on first open.
+
+### Configuration
+
+```rust
+use crdt_lite::persist::streaming::{StreamingCRDT, StreamingConfig};
+
+let config = StreamingConfig {
+    cache_capacity: 1000,           // LRU cache size (records)
+    persist_config: PersistConfig::default(), // Underlying persistence config
+};
+```
+
+### Tombstone Compaction
+
+`StreamingCRDT::compact_tombstones` follows the same safety contract as `PersistedCRDT`:
+1. Compact tombstones in memory (both hot and cold tiers)
+2. Create snapshot capturing the compacted state
+3. Unconditionally delete old WAL segments (regardless of `auto_cleanup_wal` config)
+
+**CRITICAL:** Same zombie record rules apply — only compact after ALL nodes acknowledge the version.
+
 ## Testing
 
 ### Column CRDT Tests (`tests.cpp`)

--- a/examples/persistence_example.rs
+++ b/examples/persistence_example.rs
@@ -3,7 +3,7 @@
 //! Run with: cargo run --example persistence_example --features persist
 
 #[cfg(feature = "persist")]
-use crdt_lite::persist::{PersistedCRDT, PersistConfig};
+use crdt_lite::persist::{PersistConfig, PersistedCRDT};
 #[cfg(feature = "persist")]
 use std::path::PathBuf;
 #[cfg(feature = "persist")]
@@ -11,144 +11,146 @@ use std::sync::mpsc;
 
 #[cfg(feature = "persist")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("=== CRDT Persistence Example ===\n");
+  println!("=== CRDT Persistence Example ===\n");
 
-    // Create a channel to simulate network broadcasting
-    let (tx, rx) = mpsc::channel();
+  // Create a channel to simulate network broadcasting
+  let (tx, rx) = mpsc::channel();
 
-    // Open or create a persisted CRDT
-    let data_dir = PathBuf::from("./example_data");
-    let config = PersistConfig {
-        snapshot_threshold: 5, // Snapshot every 5 changes
-        auto_cleanup_snapshots: Some(3), // Keep 3 most recent snapshots
-        max_batch_size: Some(1000), // Auto-flush batch after 1000 changes
-        ..Default::default() // Use defaults for new fields
-    };
+  // Open or create a persisted CRDT
+  let data_dir = PathBuf::from("./example_data");
+  let config = PersistConfig {
+    snapshot_threshold: 5,           // Snapshot every 5 changes
+    auto_cleanup_snapshots: Some(3), // Keep 3 most recent snapshots
+    max_batch_size: Some(1000),      // Auto-flush batch after 1000 changes
+    ..Default::default()             // Use defaults for new fields
+  };
 
-    let mut pcrdt = PersistedCRDT::<String, String, String>::open(
-        data_dir.clone(),
-        1, // node_id
-        config,
-    )?;
+  let mut pcrdt = PersistedCRDT::<String, String, String>::open(
+    data_dir.clone(),
+    1, // node_id
+    config,
+  )?;
 
-    // Add a post-operation hook to broadcast changes
-    let tx_clone = tx.clone();
-    pcrdt.add_post_hook(Box::new(move |changes: &[crdt_lite::Change<String, String, String>]| {
-        println!("📡 Broadcasting {} changes to network", changes.len());
-        let _ = tx_clone.send(changes.to_vec());
-    }));
+  // Add a post-operation hook to broadcast changes
+  let tx_clone = tx.clone();
+  pcrdt.add_post_hook(Box::new(
+    move |changes: &[crdt_lite::Change<String, String, String>]| {
+      println!("📡 Broadcasting {} changes to network", changes.len());
+      let _ = tx_clone.send(changes.to_vec());
+    },
+  ));
 
-    println!("✓ Opened PersistedCRDT at {:?}\n", data_dir);
+  println!("✓ Opened PersistedCRDT at {:?}\n", data_dir);
 
-    // Insert some user records
-    println!("Inserting user records...");
-    pcrdt.insert_or_update(
-        &"user1".to_string(),
-        [
-            ("name".to_string(), "Alice".to_string()),
-            ("email".to_string(), "alice@example.com".to_string()),
-            ("role".to_string(), "admin".to_string()),
-        ]
-        .into_iter(),
-    )?;
+  // Insert some user records
+  println!("Inserting user records...");
+  pcrdt.insert_or_update(
+    &"user1".to_string(),
+    [
+      ("name".to_string(), "Alice".to_string()),
+      ("email".to_string(), "alice@example.com".to_string()),
+      ("role".to_string(), "admin".to_string()),
+    ]
+    .into_iter(),
+  )?;
 
-    pcrdt.insert_or_update(
-        &"user2".to_string(),
-        [
-            ("name".to_string(), "Bob".to_string()),
-            ("email".to_string(), "bob@example.com".to_string()),
-            ("role".to_string(), "user".to_string()),
-        ]
-        .into_iter(),
-    )?;
+  pcrdt.insert_or_update(
+    &"user2".to_string(),
+    [
+      ("name".to_string(), "Bob".to_string()),
+      ("email".to_string(), "bob@example.com".to_string()),
+      ("role".to_string(), "user".to_string()),
+    ]
+    .into_iter(),
+  )?;
 
-    println!("✓ Inserted 2 users (6 field changes total)\n");
+  println!("✓ Inserted 2 users (6 field changes total)\n");
 
-    // Update a user
-    println!("Updating user1's role...");
-    pcrdt.insert_or_update(
-        &"user1".to_string(),
-        [("role".to_string(), "superadmin".to_string())].into_iter(),
-    )?;
+  // Update a user
+  println!("Updating user1's role...");
+  pcrdt.insert_or_update(
+    &"user1".to_string(),
+    [("role".to_string(), "superadmin".to_string())].into_iter(),
+  )?;
 
-    println!("✓ Updated user1\n");
+  println!("✓ Updated user1\n");
 
-    // Check if snapshot was created
+  // Check if snapshot was created
+  println!(
+    "Changes since last snapshot: {}",
+    pcrdt.changes_since_snapshot()
+  );
+  println!("Note: Automatic snapshot triggers at 5 changes\n");
+
+  // Get all changes for sync
+  let all_changes = pcrdt.get_changes_since(0);
+  println!("Total changes in CRDT: {}\n", all_changes.len());
+
+  // Simulate receiving changes from network
+  println!("Checking for network broadcasts...");
+  let mut total_broadcasts = 0;
+  while let Ok(_changes) = rx.try_recv() {
+    total_broadcasts += 1;
+  }
+  println!("✓ Received {} broadcast notifications\n", total_broadcasts);
+
+  // Query the data
+  println!("Current data:");
+  if let Some(user1) = pcrdt.crdt().get_record(&"user1".to_string()) {
     println!(
-        "Changes since last snapshot: {}",
-        pcrdt.changes_since_snapshot()
+      "  user1: name={}, email={}, role={}",
+      user1.fields.get("name").unwrap(),
+      user1.fields.get("email").unwrap(),
+      user1.fields.get("role").unwrap()
     );
-    println!("Note: Automatic snapshot triggers at 5 changes\n");
+  }
 
-    // Get all changes for sync
-    let all_changes = pcrdt.get_changes_since(0);
-    println!("Total changes in CRDT: {}\n", all_changes.len());
-
-    // Simulate receiving changes from network
-    println!("Checking for network broadcasts...");
-    let mut total_broadcasts = 0;
-    while let Ok(_changes) = rx.try_recv() {
-        total_broadcasts += 1;
-    }
-    println!("✓ Received {} broadcast notifications\n", total_broadcasts);
-
-    // Query the data
-    println!("Current data:");
-    if let Some(user1) = pcrdt.crdt().get_record(&"user1".to_string()) {
-        println!(
-            "  user1: name={}, email={}, role={}",
-            user1.fields.get("name").unwrap(),
-            user1.fields.get("email").unwrap(),
-            user1.fields.get("role").unwrap()
-        );
-    }
-
-    if let Some(user2) = pcrdt.crdt().get_record(&"user2".to_string()) {
-        println!(
-            "  user2: name={}, email={}, role={}",
-            user2.fields.get("name").unwrap(),
-            user2.fields.get("email").unwrap(),
-            user2.fields.get("role").unwrap()
-        );
-    }
-
-    println!("\n✓ All operations persisted to disk!");
-    println!("  Snapshot: {:?}", data_dir.join("snapshot.bin"));
-    println!("  WAL files: {:?}/wal_*.bin", data_dir);
-
-    // Demonstrate recovery
-    println!("\n=== Testing Recovery ===");
-    drop(pcrdt); // Close the CRDT
-
-    println!("Reopening from disk...");
-    let recovered =
-        PersistedCRDT::<String, String, String>::open(data_dir.clone(), 1, PersistConfig::default())?;
-
-    println!("✓ Successfully recovered from persistence!");
+  if let Some(user2) = pcrdt.crdt().get_record(&"user2".to_string()) {
     println!(
-        "  Clock time: {}",
-        recovered.crdt().get_clock().current_time()
+      "  user2: name={}, email={}, role={}",
+      user2.fields.get("name").unwrap(),
+      user2.fields.get("email").unwrap(),
+      user2.fields.get("role").unwrap()
     );
+  }
 
-    // Verify data is intact
-    if let Some(user1) = recovered.crdt().get_record(&"user1".to_string()) {
-        println!(
-            "  user1 recovered: role={}",
-            user1.fields.get("role").unwrap()
-        );
-        assert_eq!(user1.fields.get("role").unwrap(), "superadmin");
-    }
+  println!("\n✓ All operations persisted to disk!");
+  println!("  Snapshot: {:?}", data_dir.join("snapshot.bin"));
+  println!("  WAL files: {:?}/wal_*.bin", data_dir);
 
-    println!("\n✨ Persistence example complete!");
-    println!("Data directory: {:?}", data_dir);
-    println!("Run again to see recovery in action.");
+  // Demonstrate recovery
+  println!("\n=== Testing Recovery ===");
+  drop(pcrdt); // Close the CRDT
 
-    Ok(())
+  println!("Reopening from disk...");
+  let recovered =
+    PersistedCRDT::<String, String, String>::open(data_dir.clone(), 1, PersistConfig::default())?;
+
+  println!("✓ Successfully recovered from persistence!");
+  println!(
+    "  Clock time: {}",
+    recovered.crdt().get_clock().current_time()
+  );
+
+  // Verify data is intact
+  if let Some(user1) = recovered.crdt().get_record(&"user1".to_string()) {
+    println!(
+      "  user1 recovered: role={}",
+      user1.fields.get("role").unwrap()
+    );
+    assert_eq!(user1.fields.get("role").unwrap(), "superadmin");
+  }
+
+  println!("\n✨ Persistence example complete!");
+  println!("Data directory: {:?}", data_dir);
+  println!("Run again to see recovery in action.");
+
+  Ok(())
 }
 
 #[cfg(not(feature = "persist"))]
 fn main() {
-    eprintln!("This example requires the 'persist' feature.");
-    eprintln!("Run with: cargo run --example persistence_example --features persist");
-    std::process::exit(1);
+  eprintln!("This example requires the 'persist' feature.");
+  eprintln!("Run with: cargo run --example persistence_example --features persist");
+  std::process::exit(1);
 }

--- a/examples/r2_backup_example.rs
+++ b/examples/r2_backup_example.rs
@@ -3,7 +3,7 @@
 //! Run with: cargo run --example r2_backup_example --features persist
 
 #[cfg(feature = "persist")]
-use crdt_lite::persist::{PersistedCRDT, PersistConfig};
+use crdt_lite::persist::{PersistConfig, PersistedCRDT};
 #[cfg(feature = "persist")]
 use std::path::PathBuf;
 #[cfg(feature = "persist")]
@@ -11,128 +11,143 @@ use std::sync::{Arc, Mutex};
 
 #[cfg(feature = "persist")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("=== CRDT with R2 Backup Hooks ===\n");
+  println!("=== CRDT with R2 Backup Hooks ===\n");
 
-    // Simulate R2 backup tracking
-    let uploaded_snapshots = Arc::new(Mutex::new(Vec::new()));
-    let uploaded_wal_segments = Arc::new(Mutex::new(Vec::new()));
+  // Simulate R2 backup tracking
+  let uploaded_snapshots = Arc::new(Mutex::new(Vec::new()));
+  let uploaded_wal_segments = Arc::new(Mutex::new(Vec::new()));
 
-    // Open persisted CRDT
-    let data_dir = PathBuf::from("./r2_backup_example_data");
-    let config = PersistConfig {
-        snapshot_threshold: 3, // Snapshot every 3 changes for demo
-        auto_cleanup_snapshots: None, // Manual cleanup after upload verification
-        max_batch_size: Some(10000), // Default auto-flush limit
-        ..Default::default() // Use defaults for new fields
-    };
+  // Open persisted CRDT
+  let data_dir = PathBuf::from("./r2_backup_example_data");
+  let config = PersistConfig {
+    snapshot_threshold: 3,        // Snapshot every 3 changes for demo
+    auto_cleanup_snapshots: None, // Manual cleanup after upload verification
+    max_batch_size: Some(10000),  // Default auto-flush limit
+    ..Default::default()          // Use defaults for new fields
+  };
 
-    let mut pcrdt = PersistedCRDT::<String, String, String>::open(
-        data_dir.clone(),
-        1, // node_id
-        config,
+  let mut pcrdt = PersistedCRDT::<String, String, String>::open(
+    data_dir.clone(),
+    1, // node_id
+    config,
+  )?;
+
+  // Add snapshot hook - simulates uploading to R2
+  let snapshots_clone = uploaded_snapshots.clone();
+  pcrdt.add_snapshot_hook(Box::new(
+    move |snapshot_path: &std::path::Path, db_version: u64| {
+      println!(
+        "📸 Snapshot created: {:?} (db_version: {})",
+        snapshot_path.file_name().unwrap(),
+        db_version
+      );
+      println!("   └─ Uploading to R2...");
+
+      // In real app: tokio::spawn(async move { r2.put(...) })
+      // For demo: just track it
+      snapshots_clone
+        .lock()
+        .unwrap()
+        .push(snapshot_path.to_path_buf());
+
+      println!("   └─ ✓ Uploaded to R2");
+    },
+  ));
+
+  // Add WAL segment hook - simulates uploading sealed segments to R2
+  let wal_clone = uploaded_wal_segments.clone();
+  pcrdt.add_wal_segment_hook(Box::new(move |segment_path: &std::path::Path| {
+    println!(
+      "📝 WAL segment sealed: {:?}",
+      segment_path.file_name().unwrap()
+    );
+    println!("   └─ Uploading to R2...");
+
+    // In real app: tokio::spawn(async move { r2.put(...) })
+    // For demo: just track it
+    wal_clone.lock().unwrap().push(segment_path.to_path_buf());
+
+    println!("   └─ ✓ Uploaded to R2");
+  }));
+
+  println!("✓ CRDT opened with backup hooks\n");
+
+  // Insert data - will trigger snapshots and hooks
+  println!("Inserting records...\n");
+
+  for i in 1..=10 {
+    pcrdt.insert_or_update(
+      &format!("user{}", i),
+      [
+        ("name".to_string(), format!("User {}", i)),
+        ("email".to_string(), format!("user{}@example.com", i)),
+      ]
+      .into_iter(),
     )?;
 
-    // Add snapshot hook - simulates uploading to R2
-    let snapshots_clone = uploaded_snapshots.clone();
-    pcrdt.add_snapshot_hook(Box::new(move |snapshot_path: &std::path::Path, db_version: u64| {
-        println!("📸 Snapshot created: {:?} (db_version: {})", snapshot_path.file_name().unwrap(), db_version);
-        println!("   └─ Uploading to R2...");
+    println!(
+      "  → Inserted user{} ({} changes since snapshot)",
+      i,
+      pcrdt.changes_since_snapshot()
+    );
 
-        // In real app: tokio::spawn(async move { r2.put(...) })
-        // For demo: just track it
-        snapshots_clone.lock().unwrap().push(snapshot_path.to_path_buf());
+    // Small delay to show progression
+    std::thread::sleep(std::time::Duration::from_millis(100));
+  }
 
-        println!("   └─ ✓ Uploaded to R2");
-    }));
+  println!("\n✅ All operations complete!\n");
 
-    // Add WAL segment hook - simulates uploading sealed segments to R2
-    let wal_clone = uploaded_wal_segments.clone();
-    pcrdt.add_wal_segment_hook(Box::new(move |segment_path: &std::path::Path| {
-        println!("📝 WAL segment sealed: {:?}", segment_path.file_name().unwrap());
-        println!("   └─ Uploading to R2...");
+  // Show backup status
+  let snapshots = uploaded_snapshots.lock().unwrap();
+  let wal_segments = uploaded_wal_segments.lock().unwrap();
 
-        // In real app: tokio::spawn(async move { r2.put(...) })
-        // For demo: just track it
-        wal_clone.lock().unwrap().push(segment_path.to_path_buf());
+  println!("📦 Backup Summary:");
+  println!("  Snapshots uploaded: {}", snapshots.len());
+  for (i, path) in snapshots.iter().enumerate() {
+    println!("    {}. {:?}", i + 1, path.file_name().unwrap());
+  }
 
-        println!("   └─ ✓ Uploaded to R2");
-    }));
+  println!("\n  WAL segments uploaded: {}", wal_segments.len());
+  for (i, path) in wal_segments.iter().enumerate() {
+    println!("    {}. {:?}", i + 1, path.file_name().unwrap());
+  }
 
-    println!("✓ CRDT opened with backup hooks\n");
+  // Demonstrate cleanup
+  println!("\n🧹 Cleanup demo:");
+  println!("  Before cleanup:");
+  let snapshot_count_before = std::fs::read_dir(&data_dir)?
+    .filter_map(|e| e.ok())
+    .filter(|e| e.file_name().to_string_lossy().starts_with("snapshot_"))
+    .count();
+  println!("    Local snapshots: {}", snapshot_count_before);
 
-    // Insert data - will trigger snapshots and hooks
-    println!("Inserting records...\n");
+  // Keep only last 2 snapshots locally (rest are in R2)
+  // Note: In a real implementation, use require_uploaded=true and track uploads with mark_snapshot_uploaded()
+  // For this demo, we use false to cleanup all old snapshots
+  pcrdt.cleanup_old_snapshots(2, false)?;
 
-    for i in 1..=10 {
-        pcrdt.insert_or_update(
-            &format!("user{}", i),
-            [
-                ("name".to_string(), format!("User {}", i)),
-                ("email".to_string(), format!("user{}@example.com", i)),
-            ]
-            .into_iter(),
-        )?;
+  let snapshot_count_after = std::fs::read_dir(&data_dir)?
+    .filter_map(|e| e.ok())
+    .filter(|e| e.file_name().to_string_lossy().starts_with("snapshot_"))
+    .count();
+  println!("  After cleanup (keep 2):");
+  println!("    Local snapshots: {}", snapshot_count_after);
+  println!("    (Old snapshots safely backed up in R2)");
 
-        println!("  → Inserted user{} ({} changes since snapshot)",
-                 i, pcrdt.changes_since_snapshot());
+  println!("\n💡 Recovery flow:");
+  println!("  1. Container starts → Download latest snapshot from R2");
+  println!("  2. Download WAL segments since snapshot");
+  println!("  3. PersistedCRDT::open() recovers from local files");
+  println!("  4. Continue operations with hooks uploading new changes");
 
-        // Small delay to show progression
-        std::thread::sleep(std::time::Duration::from_millis(100));
-    }
+  println!("\n✨ Example complete! Data in: {:?}", data_dir);
 
-    println!("\n✅ All operations complete!\n");
-
-    // Show backup status
-    let snapshots = uploaded_snapshots.lock().unwrap();
-    let wal_segments = uploaded_wal_segments.lock().unwrap();
-
-    println!("📦 Backup Summary:");
-    println!("  Snapshots uploaded: {}", snapshots.len());
-    for (i, path) in snapshots.iter().enumerate() {
-        println!("    {}. {:?}", i + 1, path.file_name().unwrap());
-    }
-
-    println!("\n  WAL segments uploaded: {}", wal_segments.len());
-    for (i, path) in wal_segments.iter().enumerate() {
-        println!("    {}. {:?}", i + 1, path.file_name().unwrap());
-    }
-
-    // Demonstrate cleanup
-    println!("\n🧹 Cleanup demo:");
-    println!("  Before cleanup:");
-    let snapshot_count_before = std::fs::read_dir(&data_dir)?
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_name().to_string_lossy().starts_with("snapshot_"))
-        .count();
-    println!("    Local snapshots: {}", snapshot_count_before);
-
-    // Keep only last 2 snapshots locally (rest are in R2)
-    // Note: In a real implementation, use require_uploaded=true and track uploads with mark_snapshot_uploaded()
-    // For this demo, we use false to cleanup all old snapshots
-    pcrdt.cleanup_old_snapshots(2, false)?;
-
-    let snapshot_count_after = std::fs::read_dir(&data_dir)?
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_name().to_string_lossy().starts_with("snapshot_"))
-        .count();
-    println!("  After cleanup (keep 2):");
-    println!("    Local snapshots: {}", snapshot_count_after);
-    println!("    (Old snapshots safely backed up in R2)");
-
-    println!("\n💡 Recovery flow:");
-    println!("  1. Container starts → Download latest snapshot from R2");
-    println!("  2. Download WAL segments since snapshot");
-    println!("  3. PersistedCRDT::open() recovers from local files");
-    println!("  4. Continue operations with hooks uploading new changes");
-
-    println!("\n✨ Example complete! Data in: {:?}", data_dir);
-
-    Ok(())
+  Ok(())
 }
 
 #[cfg(not(feature = "persist"))]
 fn main() {
-    eprintln!("This example requires the 'persist' feature.");
-    eprintln!("Run with: cargo run --example r2_backup_example --features persist");
-    std::process::exit(1);
+  eprintln!("This example requires the 'persist' feature.");
+  eprintln!("Run with: cargo run --example r2_backup_example --features persist");
+  std::process::exit(1);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1501,6 +1501,40 @@ impl<K: Ord + Hash + Eq + Clone, C: Hash + Eq + Clone, V: Clone> CRDT<K, C, V> {
 
     None
   }
+
+  /// Mutable access to the logical clock (for internal use by persistence layer)
+  #[cfg(feature = "persist-msgpack")]
+  pub(crate) fn get_clock_mut(&mut self) -> &mut LogicalClock {
+    &mut self.clock
+  }
+
+  /// Access to tombstones (for internal use by persistence layer)
+  #[cfg(feature = "persist-msgpack")]
+  pub(crate) fn get_tombstones(&self) -> &TombstoneStorage<K> {
+    &self.tombstones
+  }
+
+  /// Insert a record directly, preserving its version metadata.
+  /// This bypasses the normal change-based API to avoid causality issues
+  /// when loading cold records into hot storage.
+  #[cfg(feature = "persist-msgpack")]
+  pub(crate) fn insert_record_direct(&mut self, key: K, record: Record<C, V>) {
+    // Update clock to be ahead of the record's versions to maintain causality
+    // Check both column versions and highest_local_db_version to handle all cases
+    let max_version = record
+      .column_versions
+      .values()
+      .map(|v| v.db_version)
+      .max()
+      .unwrap_or(0)
+      .max(record.highest_local_db_version);
+
+    // Use update() to ensure clock advances past max_version (avoids collisions)
+    if max_version >= self.clock.current_time() {
+      self.clock.update(max_version);
+    }
+    self.data.insert(key, record);
+  }
 }
 
 // Additional methods requiring Ord (sorted-keys feature only)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,11 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 // Persistence module (requires any persist-related feature)
-#[cfg(any(feature = "persist", feature = "persist-msgpack", feature = "persist-compressed"))]
+#[cfg(any(
+  feature = "persist",
+  feature = "persist-msgpack",
+  feature = "persist-compressed"
+))]
 pub mod persist;
 
 // Ensure valid feature combination: either std or alloc must be enabled
@@ -105,11 +109,7 @@ use std::{
 };
 
 #[cfg(not(feature = "std"))]
-use alloc::{
-  string::String,
-  sync::Arc,
-  vec::Vec,
-};
+use alloc::{string::String, sync::Arc, vec::Vec};
 #[cfg(not(feature = "std"))]
 use core::{cmp::Ordering, hash::Hash};
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
@@ -162,8 +162,16 @@ const TOMBSTONE_COL_VERSION: u64 = u64::MAX;
 /// - A deletion of an entire record (when `col_name` is `None`)
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(bound(serialize = "K: serde::Serialize, C: serde::Serialize, V: serde::Serialize")))]
-#[cfg_attr(feature = "serde", serde(bound(deserialize = "K: serde::de::DeserializeOwned, C: serde::de::DeserializeOwned, V: serde::de::DeserializeOwned")))]
+#[cfg_attr(
+  feature = "serde",
+  serde(bound(serialize = "K: serde::Serialize, C: serde::Serialize, V: serde::Serialize"))
+)]
+#[cfg_attr(
+  feature = "serde",
+  serde(bound(
+    deserialize = "K: serde::de::DeserializeOwned, C: serde::de::DeserializeOwned, V: serde::de::DeserializeOwned"
+  ))
+)]
 pub struct Change<K, C, V> {
   pub record_id: K,
   /// `None` represents tombstone of the record
@@ -369,8 +377,16 @@ impl<K: Hash + Eq> Default for TombstoneStorage<K> {
 /// Represents a record in the CRDT.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(bound(serialize = "C: serde::Serialize + Hash + Eq, V: serde::Serialize")))]
-#[cfg_attr(feature = "serde", serde(bound(deserialize = "C: serde::de::DeserializeOwned + Hash + Eq, V: serde::de::DeserializeOwned")))]
+#[cfg_attr(
+  feature = "serde",
+  serde(bound(serialize = "C: serde::Serialize + Hash + Eq, V: serde::Serialize"))
+)]
+#[cfg_attr(
+  feature = "serde",
+  serde(bound(
+    deserialize = "C: serde::de::DeserializeOwned + Hash + Eq, V: serde::de::DeserializeOwned"
+  ))
+)]
 pub struct Record<C, V> {
   pub fields: HashMap<C, V>,
   pub column_versions: HashMap<C, ColumnVersion>,
@@ -390,10 +406,7 @@ impl<C: Hash + Eq, V> Record<C, V> {
   }
 
   /// Creates a record from existing fields and column versions
-  pub fn from_parts(
-    fields: HashMap<C, V>,
-    column_versions: HashMap<C, ColumnVersion>,
-  ) -> Self {
+  pub fn from_parts(fields: HashMap<C, V>, column_versions: HashMap<C, ColumnVersion>) -> Self {
     let mut lowest = u64::MAX;
     let mut highest = 0;
 
@@ -558,8 +571,16 @@ impl<K: Ord, C: Ord, V> ChangeComparator<K, C, V> for DefaultChangeComparator {
 /// - This is consistent with PersistedCRDT which also requires K: Ord for serialization.
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(bound(serialize = "K: serde::Serialize, C: serde::Serialize, V: serde::Serialize")))]
-#[cfg_attr(feature = "serde", serde(bound(deserialize = "K: serde::de::DeserializeOwned + Ord + Hash + Eq + Clone, C: serde::de::DeserializeOwned + Hash + Eq + Clone, V: serde::de::DeserializeOwned + Clone")))]
+#[cfg_attr(
+  feature = "serde",
+  serde(bound(serialize = "K: serde::Serialize, C: serde::Serialize, V: serde::Serialize"))
+)]
+#[cfg_attr(
+  feature = "serde",
+  serde(bound(
+    deserialize = "K: serde::de::DeserializeOwned + Ord + Hash + Eq + Clone, C: serde::de::DeserializeOwned + Hash + Eq + Clone, V: serde::de::DeserializeOwned + Clone"
+  ))
+)]
 pub struct CRDT<K: Ord + Hash + Eq + Clone, C: Hash + Eq + Clone, V: Clone> {
   node_id: NodeId,
   clock: LogicalClock,
@@ -1409,17 +1430,19 @@ impl<K: Ord + Hash + Eq + Clone, C: Hash + Eq + Clone, V: Clone> CRDT<K, C, V> {
   /// // tombstones contains only records deleted after version 1000
   /// ```
   #[cfg(feature = "std")]
-  pub fn get_changed_since(&self, since_version: u64) -> (
-    DataMap<K, Record<C, V>>,
-    HashMap<K, TombstoneInfo>,
-  ) {
-    let records = self.data
+  pub fn get_changed_since(
+    &self,
+    since_version: u64,
+  ) -> (DataMap<K, Record<C, V>>, HashMap<K, TombstoneInfo>) {
+    let records = self
+      .data
       .iter()
       .filter(|(_, record)| record.highest_local_db_version > since_version)
       .map(|(k, v)| (k.clone(), v.clone()))
       .collect();
 
-    let tombstones = self.tombstones
+    let tombstones = self
+      .tombstones
       .iter()
       .filter(|(_, info)| info.local_db_version > since_version)
       .map(|(k, v)| (k.clone(), *v))
@@ -1430,17 +1453,19 @@ impl<K: Ord + Hash + Eq + Clone, C: Hash + Eq + Clone, V: Clone> CRDT<K, C, V> {
 
   /// Gets records and tombstones that have changed since a specific version (no_std version).
   #[cfg(not(feature = "std"))]
-  pub fn get_changed_since(&self, since_version: u64) -> (
-    DataMap<K, Record<C, V>>,
-    HashMap<K, TombstoneInfo>,
-  ) {
-    let records = self.data
+  pub fn get_changed_since(
+    &self,
+    since_version: u64,
+  ) -> (DataMap<K, Record<C, V>>, HashMap<K, TombstoneInfo>) {
+    let records = self
+      .data
       .iter()
       .filter(|(_, record)| record.highest_local_db_version > since_version)
       .map(|(k, v)| (k.clone(), v.clone()))
       .collect();
 
-    let tombstones = self.tombstones
+    let tombstones = self
+      .tombstones
       .iter()
       .filter(|(_, info)| info.local_db_version > since_version)
       .map(|(k, v)| (k.clone(), *v))
@@ -1530,7 +1555,8 @@ impl<K: Ord + Hash + Eq + Clone, C: Hash + Eq + Clone, V: Clone> CRDT<K, C, V> {
       .max(record.highest_local_db_version);
 
     // Use update() to ensure clock advances past max_version (avoids collisions)
-    if max_version >= self.clock.current_time() {
+    // Only update if max_version exceeds current time to avoid unnecessary gaps
+    if max_version > self.clock.current_time() {
       self.clock.update(max_version);
     }
     self.data.insert(key, record);
@@ -1768,7 +1794,10 @@ mod tests {
     assert_eq!(crdt.get_data().len(), deserialized.get_data().len());
     assert_eq!(
       crdt.get_record(&"user1".to_string()).unwrap().fields,
-      deserialized.get_record(&"user1".to_string()).unwrap().fields
+      deserialized
+        .get_record(&"user1".to_string())
+        .unwrap()
+        .fields
     );
 
     // Verify tombstones are preserved
@@ -1808,7 +1837,10 @@ mod tests {
     assert_eq!(crdt.get_data().len(), deserialized.get_data().len());
     assert_eq!(
       crdt.get_record(&"user1".to_string()).unwrap().fields,
-      deserialized.get_record(&"user1".to_string()).unwrap().fields
+      deserialized
+        .get_record(&"user1".to_string())
+        .unwrap()
+        .fields
     );
 
     // Verify clock is preserved
@@ -1842,10 +1874,14 @@ mod tests {
       assert!(deserialized.parent.is_none());
 
       // Verify child's own data is preserved
-      assert!(deserialized.get_record(&"child_record".to_string()).is_some());
+      assert!(deserialized
+        .get_record(&"child_record".to_string())
+        .is_some());
 
       // Verify parent's data is NOT in deserialized child
-      assert!(deserialized.get_record(&"parent_record".to_string()).is_none());
+      assert!(deserialized
+        .get_record(&"parent_record".to_string())
+        .is_none());
     }
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1547,14 +1547,23 @@ impl<K: Ord + Hash + Eq + Clone, C: Hash + Eq + Clone, V: Clone> CRDT<K, C, V> {
   /// Insert a record directly, preserving its version metadata.
   /// This bypasses the normal change-based API to avoid causality issues
   /// when loading cold records into hot storage.
+  ///
+  /// # Clock Update Strategy
+  ///
+  /// We use `local_db_version` (not `db_version`) to update the clock because:
+  /// - `db_version` is the global logical clock from the originating node
+  /// - `local_db_version` is the local clock when the change was applied on THIS node
+  ///
+  /// Using `db_version` would cause clock jumps when loading records synced from
+  /// nodes with higher clocks, violating causality and causing incorrect conflict resolution.
   #[cfg(feature = "persist-msgpack")]
   pub(crate) fn insert_record_direct(&mut self, key: K, record: Record<C, V>) {
-    // Update clock to be ahead of the record's versions to maintain causality
-    // Check both column versions and highest_local_db_version to handle all cases
+    // Update clock to be ahead of the record's LOCAL versions to maintain causality
+    // Use local_db_version (not db_version) to avoid clock jumps from remote nodes
     let max_version = record
       .column_versions
       .values()
-      .map(|v| v.db_version)
+      .map(|v| v.local_db_version)
       .max()
       .unwrap_or(0)
       .max(record.highest_local_db_version);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1291,6 +1291,11 @@ impl<K: Ord + Hash + Eq + Clone, C: Hash + Eq + Clone, V: Clone> CRDT<K, C, V> {
     &self.clock
   }
 
+  /// Gets the node ID for this CRDT.
+  pub fn node_id(&self) -> NodeId {
+    self.node_id
+  }
+
   /// Gets a reference to the internal data map.
   pub fn get_data(&self) -> &DataMap<K, Record<C, V>> {
     &self.data
@@ -1554,10 +1559,10 @@ impl<K: Ord + Hash + Eq + Clone, C: Hash + Eq + Clone, V: Clone> CRDT<K, C, V> {
       .unwrap_or(0)
       .max(record.highest_local_db_version);
 
-    // Use update() to ensure clock advances past max_version (avoids collisions)
-    // Only update if max_version exceeds current time to avoid unnecessary gaps
+    // Use direct assignment instead of update() to avoid creating version gaps
+    // Only set if max_version exceeds current time
     if max_version > self.clock.current_time() {
-      self.clock.update(max_version);
+      self.clock.set_time(max_version);
     }
     self.data.insert(key, record);
   }

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -886,7 +886,7 @@ where
   /// and any incremental snapshots that build on it.
   #[cfg(feature = "msgpack")]
   #[allow(clippy::type_complexity)]
-  fn discover_snapshots(
+  pub(crate) fn discover_snapshots(
     base_dir: &PathBuf,
   ) -> Result<(Option<(PathBuf, u64)>, Vec<(PathBuf, u64)>), PersistError> {
     let mut full_snapshots: Vec<(PathBuf, u64)> = Vec::new();

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -127,58 +127,66 @@ type DataMap<K, V> = std::collections::BTreeMap<K, V>;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SnapshotFormat {
-    /// Legacy bincode format (no schema evolution)
-    Bincode,
-    /// MessagePack format (supports schema evolution)
-    MessagePack,
+  /// Legacy bincode format (no schema evolution)
+  Bincode,
+  /// MessagePack format (supports schema evolution)
+  MessagePack,
 }
 
 /// Snapshot type - either full or incremental.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SnapshotType {
-    /// Full snapshot containing entire CRDT state
-    Full,
-    /// Incremental snapshot containing only changes since a base version
-    Incremental {
-        /// The base version this incremental builds on
-        base_version: u64,
-    },
+  /// Full snapshot containing entire CRDT state
+  Full,
+  /// Incremental snapshot containing only changes since a base version
+  Incremental {
+    /// The base version this incremental builds on
+    base_version: u64,
+  },
 }
 
 /// Metadata for snapshots (both full and incremental).
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SnapshotMetadata {
-    /// Type of snapshot (full or incremental)
-    pub snapshot_type: SnapshotType,
-    /// The logical clock version this snapshot represents
-    pub version: u64,
-    /// Format used for serialization
-    pub format: SnapshotFormat,
-    /// Timestamp when snapshot was created
-    pub created_at: u64,
+  /// Type of snapshot (full or incremental)
+  pub snapshot_type: SnapshotType,
+  /// The logical clock version this snapshot represents
+  pub version: u64,
+  /// Format used for serialization
+  pub format: SnapshotFormat,
+  /// Timestamp when snapshot was created
+  pub created_at: u64,
 }
 
 /// Incremental snapshot structure for MessagePack serialization.
 #[cfg(feature = "msgpack")]
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(bound(serialize = "K: serde::Serialize, C: serde::Serialize, V: serde::Serialize")))]
-#[cfg_attr(feature = "serde", serde(bound(deserialize = "K: serde::de::DeserializeOwned + Ord + Hash + Eq + Clone, C: serde::de::DeserializeOwned + Hash + Eq + Clone, V: serde::de::DeserializeOwned + Clone")))]
+#[cfg_attr(
+  feature = "serde",
+  serde(bound(serialize = "K: serde::Serialize, C: serde::Serialize, V: serde::Serialize"))
+)]
+#[cfg_attr(
+  feature = "serde",
+  serde(bound(
+    deserialize = "K: serde::de::DeserializeOwned + Ord + Hash + Eq + Clone, C: serde::de::DeserializeOwned + Hash + Eq + Clone, V: serde::de::DeserializeOwned + Clone"
+  ))
+)]
 pub struct IncrementalSnapshot<K, C, V>
 where
-    K: Ord + Hash + Eq + Clone,
-    C: Hash + Eq + Clone,
-    V: Clone,
+  K: Ord + Hash + Eq + Clone,
+  C: Hash + Eq + Clone,
+  V: Clone,
 {
-    pub metadata: SnapshotMetadata,
-    /// Only records that changed since base version
-    pub changed_records: DataMap<K, Record<C, V>>,
-    /// Only tombstones added since base version
-    pub new_tombstones: HashMap<K, TombstoneInfo>,
-    /// Updated logical clock
-    pub clock_version: u64,
+  pub metadata: SnapshotMetadata,
+  /// Only records that changed since base version
+  pub changed_records: DataMap<K, Record<C, V>>,
+  /// Only tombstones added since base version
+  pub new_tombstones: HashMap<K, TombstoneInfo>,
+  /// Updated logical clock
+  pub clock_version: u64,
 }
 
 /// Default snapshot threshold: create snapshot every 1000 changes
@@ -225,129 +233,129 @@ pub const DEFAULT_FULL_SNAPSHOT_INTERVAL: usize = 10;
 /// Configuration for the persistence layer.
 #[derive(Debug, Clone)]
 pub struct PersistConfig {
-    /// Number of changes before automatic snapshot creation
-    pub snapshot_threshold: usize,
-    /// Time interval in seconds before automatic snapshot creation
-    /// Set to None to disable time-based snapshots
-    pub snapshot_interval_secs: Option<u64>,
-    /// Auto-cleanup old snapshots after rotation (None = manual cleanup only, Some(N) = keep N most recent)
-    pub auto_cleanup_snapshots: Option<usize>,
-    /// Maximum number of changes to accumulate in batch before auto-flush
-    /// Set to None to disable auto-flush (you MUST call take_batch() periodically)
-    pub max_batch_size: Option<usize>,
-    /// Snapshot format (Bincode or MessagePack)
-    pub snapshot_format: SnapshotFormat,
-    /// Enable incremental snapshots (only available with MessagePack)
-    pub enable_incremental_snapshots: bool,
-    /// Number of incremental snapshots before creating a full snapshot
-    pub full_snapshot_interval: usize,
-    /// Enable compression (zstd) for snapshots
-    pub enable_compression: bool,
-    /// Skip creating incremental snapshots when there are no changes
-    pub skip_empty_incrementals: bool,
+  /// Number of changes before automatic snapshot creation
+  pub snapshot_threshold: usize,
+  /// Time interval in seconds before automatic snapshot creation
+  /// Set to None to disable time-based snapshots
+  pub snapshot_interval_secs: Option<u64>,
+  /// Auto-cleanup old snapshots after rotation (None = manual cleanup only, Some(N) = keep N most recent)
+  pub auto_cleanup_snapshots: Option<usize>,
+  /// Maximum number of changes to accumulate in batch before auto-flush
+  /// Set to None to disable auto-flush (you MUST call take_batch() periodically)
+  pub max_batch_size: Option<usize>,
+  /// Snapshot format (Bincode or MessagePack)
+  pub snapshot_format: SnapshotFormat,
+  /// Enable incremental snapshots (only available with MessagePack)
+  pub enable_incremental_snapshots: bool,
+  /// Number of incremental snapshots before creating a full snapshot
+  pub full_snapshot_interval: usize,
+  /// Enable compression (zstd) for snapshots
+  pub enable_compression: bool,
+  /// Skip creating incremental snapshots when there are no changes
+  pub skip_empty_incrementals: bool,
 }
 
 impl Default for PersistConfig {
-    fn default() -> Self {
-        Self {
-            snapshot_threshold: DEFAULT_SNAPSHOT_THRESHOLD,
-            snapshot_interval_secs: Some(DEFAULT_SNAPSHOT_INTERVAL_SECS),
-            auto_cleanup_snapshots: Some(DEFAULT_AUTO_CLEANUP_SNAPSHOTS),
-            max_batch_size: Some(DEFAULT_MAX_BATCH_SIZE),
-            // Default to MessagePack if available (schema evolution support),
-            // otherwise fall back to Bincode (legacy persist feature)
-            snapshot_format: {
-                #[cfg(feature = "msgpack")]
-                {
-                    SnapshotFormat::MessagePack
-                }
-                #[cfg(not(feature = "msgpack"))]
-                {
-                    SnapshotFormat::Bincode
-                }
-            },
-            enable_incremental_snapshots: true,
-            full_snapshot_interval: DEFAULT_FULL_SNAPSHOT_INTERVAL,
-            enable_compression: false,
-            skip_empty_incrementals: true,
+  fn default() -> Self {
+    Self {
+      snapshot_threshold: DEFAULT_SNAPSHOT_THRESHOLD,
+      snapshot_interval_secs: Some(DEFAULT_SNAPSHOT_INTERVAL_SECS),
+      auto_cleanup_snapshots: Some(DEFAULT_AUTO_CLEANUP_SNAPSHOTS),
+      max_batch_size: Some(DEFAULT_MAX_BATCH_SIZE),
+      // Default to MessagePack if available (schema evolution support),
+      // otherwise fall back to Bincode (legacy persist feature)
+      snapshot_format: {
+        #[cfg(feature = "msgpack")]
+        {
+          SnapshotFormat::MessagePack
         }
+        #[cfg(not(feature = "msgpack"))]
+        {
+          SnapshotFormat::Bincode
+        }
+      },
+      enable_incremental_snapshots: true,
+      full_snapshot_interval: DEFAULT_FULL_SNAPSHOT_INTERVAL,
+      enable_compression: false,
+      skip_empty_incrementals: true,
     }
+  }
 }
 
 /// Error types for persistence operations.
 #[derive(Debug)]
 pub enum PersistError {
-    /// I/O error during file operations
-    Io(io::Error),
-    /// Bincode serialization error
-    BincodeEncode(bincode::error::EncodeError),
-    /// Bincode deserialization error
-    BincodeDecode(bincode::error::DecodeError),
-    /// MessagePack encoding error
-    #[cfg(feature = "msgpack")]
-    MsgpackEncode(rmp_serde::encode::Error),
-    /// MessagePack decoding error
-    #[cfg(feature = "msgpack")]
-    MsgpackDecode(rmp_serde::decode::Error),
-    /// Compression error
-    #[cfg(feature = "compression")]
-    Compression(std::io::Error),
-    /// Invalid persistence directory structure
-    InvalidDirectory(String),
-    /// Unsupported feature (e.g., incremental snapshots with bincode)
-    UnsupportedFeature(String),
+  /// I/O error during file operations
+  Io(io::Error),
+  /// Bincode serialization error
+  BincodeEncode(bincode::error::EncodeError),
+  /// Bincode deserialization error
+  BincodeDecode(bincode::error::DecodeError),
+  /// MessagePack encoding error
+  #[cfg(feature = "msgpack")]
+  MsgpackEncode(rmp_serde::encode::Error),
+  /// MessagePack decoding error
+  #[cfg(feature = "msgpack")]
+  MsgpackDecode(rmp_serde::decode::Error),
+  /// Compression error
+  #[cfg(feature = "compression")]
+  Compression(std::io::Error),
+  /// Invalid persistence directory structure
+  InvalidDirectory(String),
+  /// Unsupported feature (e.g., incremental snapshots with bincode)
+  UnsupportedFeature(String),
 }
 
 impl std::fmt::Display for PersistError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            PersistError::Io(e) => write!(f, "I/O error: {}", e),
-            PersistError::BincodeEncode(e) => write!(f, "Bincode encoding error: {}", e),
-            PersistError::BincodeDecode(e) => write!(f, "Bincode decoding error: {}", e),
-            #[cfg(feature = "msgpack")]
-            PersistError::MsgpackEncode(e) => write!(f, "MessagePack encoding error: {}", e),
-            #[cfg(feature = "msgpack")]
-            PersistError::MsgpackDecode(e) => write!(f, "MessagePack decoding error: {}", e),
-            #[cfg(feature = "compression")]
-            PersistError::Compression(e) => write!(f, "Compression error: {}", e),
-            PersistError::InvalidDirectory(msg) => write!(f, "Invalid directory: {}", msg),
-            PersistError::UnsupportedFeature(msg) => write!(f, "Unsupported feature: {}", msg),
-        }
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      PersistError::Io(e) => write!(f, "I/O error: {}", e),
+      PersistError::BincodeEncode(e) => write!(f, "Bincode encoding error: {}", e),
+      PersistError::BincodeDecode(e) => write!(f, "Bincode decoding error: {}", e),
+      #[cfg(feature = "msgpack")]
+      PersistError::MsgpackEncode(e) => write!(f, "MessagePack encoding error: {}", e),
+      #[cfg(feature = "msgpack")]
+      PersistError::MsgpackDecode(e) => write!(f, "MessagePack decoding error: {}", e),
+      #[cfg(feature = "compression")]
+      PersistError::Compression(e) => write!(f, "Compression error: {}", e),
+      PersistError::InvalidDirectory(msg) => write!(f, "Invalid directory: {}", msg),
+      PersistError::UnsupportedFeature(msg) => write!(f, "Unsupported feature: {}", msg),
     }
+  }
 }
 
 impl std::error::Error for PersistError {}
 
 impl From<io::Error> for PersistError {
-    fn from(e: io::Error) -> Self {
-        PersistError::Io(e)
-    }
+  fn from(e: io::Error) -> Self {
+    PersistError::Io(e)
+  }
 }
 
 impl From<bincode::error::EncodeError> for PersistError {
-    fn from(e: bincode::error::EncodeError) -> Self {
-        PersistError::BincodeEncode(e)
-    }
+  fn from(e: bincode::error::EncodeError) -> Self {
+    PersistError::BincodeEncode(e)
+  }
 }
 
 impl From<bincode::error::DecodeError> for PersistError {
-    fn from(e: bincode::error::DecodeError) -> Self {
-        PersistError::BincodeDecode(e)
-    }
+  fn from(e: bincode::error::DecodeError) -> Self {
+    PersistError::BincodeDecode(e)
+  }
 }
 
 #[cfg(feature = "msgpack")]
 impl From<rmp_serde::encode::Error> for PersistError {
-    fn from(e: rmp_serde::encode::Error) -> Self {
-        PersistError::MsgpackEncode(e)
-    }
+  fn from(e: rmp_serde::encode::Error) -> Self {
+    PersistError::MsgpackEncode(e)
+  }
 }
 
 #[cfg(feature = "msgpack")]
 impl From<rmp_serde::decode::Error> for PersistError {
-    fn from(e: rmp_serde::decode::Error) -> Self {
-        PersistError::MsgpackDecode(e)
-    }
+  fn from(e: rmp_serde::decode::Error) -> Self {
+    PersistError::MsgpackDecode(e)
+  }
 }
 
 /// A CRDT with persistence, WAL, and hook support.
@@ -365,1047 +373,1053 @@ impl From<rmp_serde::decode::Error> for PersistError {
 /// - `V`: Value type (must be `Clone`)
 pub struct PersistedCRDT<K, C, V>
 where
-    K: Ord + Hash + Eq + Clone,
-    C: Hash + Eq + Clone,
-    V: Clone,
+  K: Ord + Hash + Eq + Clone,
+  C: Hash + Eq + Clone,
+  V: Clone,
 {
-    /// The underlying CRDT instance
-    crdt: CRDT<K, C, V>,
-    /// WAL writer for append-only change log
-    wal: WalWriter<K, C, V>,
-    /// Persistence configuration
-    config: PersistConfig,
-    /// Post-operation hooks (broadcasting)
-    post_hooks: Vec<Box<dyn PostOpHook<K, C, V>>>,
-    /// Snapshot hooks (backup/replication)
-    snapshot_hooks: Vec<Box<dyn SnapshotHook>>,
-    /// WAL segment hooks (archival)
-    wal_segment_hooks: Vec<Box<dyn WalSegmentHook>>,
-    /// Changes accumulated since last snapshot
-    changes_since_snapshot: usize,
-    /// Current snapshot version number
-    snapshot_version: u64,
-    /// Base directory for persistence files
-    base_dir: std::path::PathBuf,
-    /// Uploaded snapshots tracking (for safe cleanup)
-    uploaded_snapshots: HashSet<PathBuf>,
-    /// Uploaded WAL segments tracking (for safe cleanup)
-    uploaded_wal_segments: HashSet<PathBuf>,
-    /// Batch change collector for network broadcasting
-    batch: Vec<Change<K, C, V>>,
-    /// Last time snapshot was created (for time-based snapshots)
-    last_snapshot_time: std::time::Instant,
-    /// Number of incremental snapshots created since last full snapshot
-    incremental_snapshot_count: usize,
-    /// Tracker for base snapshot version for incrementals
-    last_full_snapshot_version: u64,
-    /// CRDT version at time of last snapshot (for incremental detection)
-    last_snapshot_crdt_version: u64,
+  /// The underlying CRDT instance
+  crdt: CRDT<K, C, V>,
+  /// WAL writer for append-only change log
+  wal: WalWriter<K, C, V>,
+  /// Persistence configuration
+  config: PersistConfig,
+  /// Post-operation hooks (broadcasting)
+  post_hooks: Vec<Box<dyn PostOpHook<K, C, V>>>,
+  /// Snapshot hooks (backup/replication)
+  snapshot_hooks: Vec<Box<dyn SnapshotHook>>,
+  /// WAL segment hooks (archival)
+  wal_segment_hooks: Vec<Box<dyn WalSegmentHook>>,
+  /// Changes accumulated since last snapshot
+  changes_since_snapshot: usize,
+  /// Current snapshot version number
+  snapshot_version: u64,
+  /// Base directory for persistence files
+  base_dir: std::path::PathBuf,
+  /// Uploaded snapshots tracking (for safe cleanup)
+  uploaded_snapshots: HashSet<PathBuf>,
+  /// Uploaded WAL segments tracking (for safe cleanup)
+  uploaded_wal_segments: HashSet<PathBuf>,
+  /// Batch change collector for network broadcasting
+  batch: Vec<Change<K, C, V>>,
+  /// Last time snapshot was created (for time-based snapshots)
+  last_snapshot_time: std::time::Instant,
+  /// Number of incremental snapshots created since last full snapshot
+  incremental_snapshot_count: usize,
+  /// Tracker for base snapshot version for incrementals
+  last_full_snapshot_version: u64,
+  /// CRDT version at time of last snapshot (for incremental detection)
+  last_snapshot_crdt_version: u64,
 }
 
 impl<K, C, V> PersistedCRDT<K, C, V>
 where
-    K: Ord + Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
-    C: Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
-    V: Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+  K: Ord + Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+  C: Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+  V: Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
 {
-    /// Opens or creates a persisted CRDT at the specified path.
-    ///
-    /// If the directory contains a snapshot and WAL files, they are loaded and replayed.
-    /// Otherwise, a new empty CRDT is created.
-    ///
-    /// # Arguments
-    ///
-    /// * `base_dir` - Directory for persistence files (created if doesn't exist)
-    /// * `node_id` - Unique identifier for this node
-    /// * `config` - Persistence configuration
-    ///
-    /// # Errors
-    ///
-    /// Returns `PersistError` if:
-    /// - Directory cannot be created
-    /// - Existing files are corrupted
-    /// - I/O errors occur
-    pub fn open(
-        base_dir: PathBuf,
-        node_id: NodeId,
-        config: PersistConfig,
-    ) -> Result<Self, PersistError> {
-        // Create directory if it doesn't exist
-        std::fs::create_dir_all(&base_dir)?;
+  /// Opens or creates a persisted CRDT at the specified path.
+  ///
+  /// If the directory contains a snapshot and WAL files, they are loaded and replayed.
+  /// Otherwise, a new empty CRDT is created.
+  ///
+  /// # Arguments
+  ///
+  /// * `base_dir` - Directory for persistence files (created if doesn't exist)
+  /// * `node_id` - Unique identifier for this node
+  /// * `config` - Persistence configuration
+  ///
+  /// # Errors
+  ///
+  /// Returns `PersistError` if:
+  /// - Directory cannot be created
+  /// - Existing files are corrupted
+  /// - I/O errors occur
+  pub fn open(
+    base_dir: PathBuf,
+    node_id: NodeId,
+    config: PersistConfig,
+  ) -> Result<Self, PersistError> {
+    // Create directory if it doesn't exist
+    std::fs::create_dir_all(&base_dir)?;
 
-        // Try to load existing state
-        let (crdt, wal, changes_since_snapshot, snapshot_version) = Self::recover(&base_dir, node_id)?;
+    // Try to load existing state
+    let (crdt, wal, changes_since_snapshot, snapshot_version) = Self::recover(&base_dir, node_id)?;
 
-        let crdt_version = crdt.get_clock().current_time();
+    let crdt_version = crdt.get_clock().current_time();
 
-        Ok(Self {
-            crdt,
-            wal,
-            config,
-            post_hooks: Vec::new(),
-            snapshot_hooks: Vec::new(),
-            wal_segment_hooks: Vec::new(),
-            changes_since_snapshot,
-            snapshot_version,
-            base_dir,
-            batch: Vec::new(),
-            uploaded_snapshots: HashSet::new(),
-            uploaded_wal_segments: HashSet::new(),
-            last_snapshot_time: Instant::now(),
-            incremental_snapshot_count: 0,
-            last_full_snapshot_version: snapshot_version,
-            last_snapshot_crdt_version: crdt_version,
-        })
-    }
+    Ok(Self {
+      crdt,
+      wal,
+      config,
+      post_hooks: Vec::new(),
+      snapshot_hooks: Vec::new(),
+      wal_segment_hooks: Vec::new(),
+      changes_since_snapshot,
+      snapshot_version,
+      base_dir,
+      batch: Vec::new(),
+      uploaded_snapshots: HashSet::new(),
+      uploaded_wal_segments: HashSet::new(),
+      last_snapshot_time: Instant::now(),
+      incremental_snapshot_count: 0,
+      last_full_snapshot_version: snapshot_version,
+      last_snapshot_crdt_version: crdt_version,
+    })
+  }
 
-    /// Returns a reference to the underlying CRDT for read-only operations.
-    ///
-    /// Use this for queries that don't modify the CRDT state.
-    pub fn crdt(&self) -> &CRDT<K, C, V> {
-        &self.crdt
-    }
+  /// Returns a reference to the underlying CRDT for read-only operations.
+  ///
+  /// Use this for queries that don't modify the CRDT state.
+  pub fn crdt(&self) -> &CRDT<K, C, V> {
+    &self.crdt
+  }
 
-    /// Adds a post-operation hook for broadcasting.
-    ///
-    /// Post-hooks are called after an operation has been successfully applied
-    /// and persisted. They cannot reject the operation.
-    pub fn add_post_hook(&mut self, hook: Box<dyn PostOpHook<K, C, V>>) {
-        self.post_hooks.push(hook);
-    }
+  /// Adds a post-operation hook for broadcasting.
+  ///
+  /// Post-hooks are called after an operation has been successfully applied
+  /// and persisted. They cannot reject the operation.
+  pub fn add_post_hook(&mut self, hook: Box<dyn PostOpHook<K, C, V>>) {
+    self.post_hooks.push(hook);
+  }
 
-    /// Adds a snapshot hook for backup/replication.
-    ///
-    /// Snapshot hooks are called after a snapshot has been created and fsynced.
-    /// The snapshot file is immutable (sealed) and safe to upload/copy.
-    pub fn add_snapshot_hook(&mut self, hook: Box<dyn SnapshotHook>) {
-        self.snapshot_hooks.push(hook);
-    }
+  /// Adds a snapshot hook for backup/replication.
+  ///
+  /// Snapshot hooks are called after a snapshot has been created and fsynced.
+  /// The snapshot file is immutable (sealed) and safe to upload/copy.
+  pub fn add_snapshot_hook(&mut self, hook: Box<dyn SnapshotHook>) {
+    self.snapshot_hooks.push(hook);
+  }
 
-    /// Adds a WAL segment hook for archival.
-    ///
-    /// WAL segment hooks are called after a segment has been sealed (rotated out).
-    /// The segment file is immutable and safe to upload/archive.
-    pub fn add_wal_segment_hook(&mut self, hook: Box<dyn WalSegmentHook>) {
-        self.wal_segment_hooks.push(hook);
-    }
+  /// Adds a WAL segment hook for archival.
+  ///
+  /// WAL segment hooks are called after a segment has been sealed (rotated out).
+  /// The segment file is immutable and safe to upload/archive.
+  pub fn add_wal_segment_hook(&mut self, hook: Box<dyn WalSegmentHook>) {
+    self.wal_segment_hooks.push(hook);
+  }
 
-    /// Returns the accumulated batch of changes and clears the collector.
-    ///
-    /// # Auto-Flush Protection
-    ///
-    /// By default (`max_batch_size: Some(10000)`), the batch is automatically cleared when it reaches
-    /// 10,000 changes to prevent OOM. **Changes are discarded silently** when this happens!
-    ///
-    /// To prevent losing changes:
-    /// - Call `take_batch()` regularly (every 100-1000 ops or 1-10 seconds)
-    /// - Monitor batch size with `peek_batch().len()`
-    /// - Set `max_batch_size: None` if you have a reliable polling loop
-    ///
-    /// # Memory Usage Without Auto-Flush
-    ///
-    /// At 1000 ops/sec with typical changes (~200 bytes each):
-    /// - After 1 second: ~200 KB
-    /// - After 1 minute: ~12 MB
-    /// - After 1 hour: ~720 MB (exceeds default limit after 10 seconds)
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// # use crdt_lite::persist::{PersistedCRDT, PersistConfig};
-    /// # use std::path::PathBuf;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let mut pcrdt = PersistedCRDT::<String, String, String>::open(
-    /// #     PathBuf::from("./data"), 1, PersistConfig::default())?;
-    /// // Perform operations...
-    /// for i in 0..100 {
-    ///     pcrdt.insert_or_update(&format!("rec{}", i),
-    ///         [("field".to_string(), "value".to_string())].into_iter())?;
-    /// }
-    ///
-    /// // Take batch and broadcast to network
-    /// let batch = pcrdt.take_batch();
-    /// // network.broadcast(batch);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn take_batch(&mut self) -> Vec<Change<K, C, V>> {
-        std::mem::take(&mut self.batch)
-    }
+  /// Returns the accumulated batch of changes and clears the collector.
+  ///
+  /// # Auto-Flush Protection
+  ///
+  /// By default (`max_batch_size: Some(10000)`), the batch is automatically cleared when it reaches
+  /// 10,000 changes to prevent OOM. **Changes are discarded silently** when this happens!
+  ///
+  /// To prevent losing changes:
+  /// - Call `take_batch()` regularly (every 100-1000 ops or 1-10 seconds)
+  /// - Monitor batch size with `peek_batch().len()`
+  /// - Set `max_batch_size: None` if you have a reliable polling loop
+  ///
+  /// # Memory Usage Without Auto-Flush
+  ///
+  /// At 1000 ops/sec with typical changes (~200 bytes each):
+  /// - After 1 second: ~200 KB
+  /// - After 1 minute: ~12 MB
+  /// - After 1 hour: ~720 MB (exceeds default limit after 10 seconds)
+  ///
+  /// # Example
+  ///
+  /// ```no_run
+  /// # use crdt_lite::persist::{PersistedCRDT, PersistConfig};
+  /// # use std::path::PathBuf;
+  /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+  /// # let mut pcrdt = PersistedCRDT::<String, String, String>::open(
+  /// #     PathBuf::from("./data"), 1, PersistConfig::default())?;
+  /// // Perform operations...
+  /// for i in 0..100 {
+  ///     pcrdt.insert_or_update(&format!("rec{}", i),
+  ///         [("field".to_string(), "value".to_string())].into_iter())?;
+  /// }
+  ///
+  /// // Take batch and broadcast to network
+  /// let batch = pcrdt.take_batch();
+  /// // network.broadcast(batch);
+  /// # Ok(())
+  /// # }
+  /// ```
+  pub fn take_batch(&mut self) -> Vec<Change<K, C, V>> {
+    std::mem::take(&mut self.batch)
+  }
 
-    /// Returns a reference to the current batch without clearing it.
-    ///
-    /// **WARNING**: This does NOT clear the batch. Memory will continue to grow until
-    /// `take_batch()` is called. See `take_batch()` documentation for memory usage warnings.
-    pub fn peek_batch(&self) -> &[Change<K, C, V>] {
-        &self.batch
-    }
+  /// Returns a reference to the current batch without clearing it.
+  ///
+  /// **WARNING**: This does NOT clear the batch. Memory will continue to grow until
+  /// `take_batch()` is called. See `take_batch()` documentation for memory usage warnings.
+  pub fn peek_batch(&self) -> &[Change<K, C, V>] {
+    &self.batch
+  }
 
-    /// Marks a snapshot as successfully uploaded.
-    ///
-    /// Call this from a `SnapshotHook` after successfully uploading the snapshot to remote storage.
-    /// Only snapshots marked as uploaded will be eligible for auto-cleanup (if configured).
-    ///
-    /// # Arguments
-    ///
-    /// * `snapshot_path` - Path to the snapshot file that was uploaded
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// # use crdt_lite::persist::{PersistedCRDT, PersistConfig, SnapshotHook};
-    /// # use std::path::PathBuf;
-    /// # use std::sync::{Arc, Mutex};
-    /// struct R2Uploader {
-    ///     pcrdt: Arc<Mutex<PersistedCRDT<String, String, String>>>,
-    /// }
-    ///
-    /// impl SnapshotHook for R2Uploader {
-    ///     fn on_snapshot(&self, snapshot_path: &PathBuf, version: u64) {
-    ///         let path = snapshot_path.clone();
-    ///         let pcrdt = self.pcrdt.clone();
-    ///
-    ///         // Spawn async upload task
-    ///         tokio::spawn(async move {
-    ///             // Upload to R2...
-    ///             // r2.put(format!("snapshots/{}/v{}", path.file_name()?, version), data).await?;
-    ///
-    ///             // Mark as uploaded for safe cleanup
-    ///             pcrdt.lock().unwrap().mark_snapshot_uploaded(path);
-    ///         });
-    ///     }
-    /// }
-    /// ```
-    pub fn mark_snapshot_uploaded(&mut self, snapshot_path: PathBuf) {
-        self.uploaded_snapshots.insert(snapshot_path);
-    }
+  /// Marks a snapshot as successfully uploaded.
+  ///
+  /// Call this from a `SnapshotHook` after successfully uploading the snapshot to remote storage.
+  /// Only snapshots marked as uploaded will be eligible for auto-cleanup (if configured).
+  ///
+  /// # Arguments
+  ///
+  /// * `snapshot_path` - Path to the snapshot file that was uploaded
+  ///
+  /// # Example
+  ///
+  /// ```ignore
+  /// # use crdt_lite::persist::{PersistedCRDT, PersistConfig, SnapshotHook};
+  /// # use std::path::PathBuf;
+  /// # use std::sync::{Arc, Mutex};
+  /// struct R2Uploader {
+  ///     pcrdt: Arc<Mutex<PersistedCRDT<String, String, String>>>,
+  /// }
+  ///
+  /// impl SnapshotHook for R2Uploader {
+  ///     fn on_snapshot(&self, snapshot_path: &PathBuf, version: u64) {
+  ///         let path = snapshot_path.clone();
+  ///         let pcrdt = self.pcrdt.clone();
+  ///
+  ///         // Spawn async upload task
+  ///         tokio::spawn(async move {
+  ///             // Upload to R2...
+  ///             // r2.put(format!("snapshots/{}/v{}", path.file_name()?, version), data).await?;
+  ///
+  ///             // Mark as uploaded for safe cleanup
+  ///             pcrdt.lock().unwrap().mark_snapshot_uploaded(path);
+  ///         });
+  ///     }
+  /// }
+  /// ```
+  pub fn mark_snapshot_uploaded(&mut self, snapshot_path: PathBuf) {
+    self.uploaded_snapshots.insert(snapshot_path);
+  }
 
-    /// Mark a WAL segment as successfully uploaded.
-    ///
-    /// Used in conjunction with `cleanup_old_wal_segments(keep_count, true)` to ensure
-    /// only uploaded segments are deleted.
-    ///
-    /// # Example with R2 Upload
-    ///
-    /// ```ignore
-    /// struct R2Uploader {
-    ///     pcrdt: Arc<Mutex<PersistedCRDT<String, String, String>>>,
-    /// }
-    ///
-    /// impl WalSegmentHook for R2Uploader {
-    ///     fn on_wal_sealed(&self, segment_path: &PathBuf) {
-    ///         let path = segment_path.clone();
-    ///         let pcrdt = self.pcrdt.clone();
-    ///
-    ///         // Spawn async upload task
-    ///         tokio::spawn(async move {
-    ///             // Upload to R2...
-    ///             // r2.put(segment_path, data).await?;
-    ///
-    ///             // Mark as uploaded for safe cleanup
-    ///             pcrdt.lock().unwrap().mark_wal_segment_uploaded(path);
-    ///         });
-    ///     }
-    /// }
-    /// ```
-    pub fn mark_wal_segment_uploaded(&mut self, segment_path: PathBuf) {
-        self.uploaded_wal_segments.insert(segment_path);
-    }
+  /// Mark a WAL segment as successfully uploaded.
+  ///
+  /// Used in conjunction with `cleanup_old_wal_segments(keep_count, true)` to ensure
+  /// only uploaded segments are deleted.
+  ///
+  /// # Example with R2 Upload
+  ///
+  /// ```ignore
+  /// struct R2Uploader {
+  ///     pcrdt: Arc<Mutex<PersistedCRDT<String, String, String>>>,
+  /// }
+  ///
+  /// impl WalSegmentHook for R2Uploader {
+  ///     fn on_wal_sealed(&self, segment_path: &PathBuf) {
+  ///         let path = segment_path.clone();
+  ///         let pcrdt = self.pcrdt.clone();
+  ///
+  ///         // Spawn async upload task
+  ///         tokio::spawn(async move {
+  ///             // Upload to R2...
+  ///             // r2.put(segment_path, data).await?;
+  ///
+  ///             // Mark as uploaded for safe cleanup
+  ///             pcrdt.lock().unwrap().mark_wal_segment_uploaded(path);
+  ///         });
+  ///     }
+  /// }
+  /// ```
+  pub fn mark_wal_segment_uploaded(&mut self, segment_path: PathBuf) {
+    self.uploaded_wal_segments.insert(segment_path);
+  }
 
-    /// Manually trigger a snapshot.
-    ///
-    /// This writes the current CRDT state to disk, fsyncs it, and rotates the WAL.
-    /// Snapshots are also created automatically based on `snapshot_threshold`.
-    pub fn snapshot(&mut self) -> Result<(), PersistError> {
-        self.create_snapshot()
-    }
+  /// Manually trigger a snapshot.
+  ///
+  /// This writes the current CRDT state to disk, fsyncs it, and rotates the WAL.
+  /// Snapshots are also created automatically based on `snapshot_threshold`.
+  pub fn snapshot(&mut self) -> Result<(), PersistError> {
+    self.create_snapshot()
+  }
 
-    /// Get the current number of changes since the last snapshot.
-    pub fn changes_since_snapshot(&self) -> usize {
-        self.changes_since_snapshot
-    }
+  /// Get the current number of changes since the last snapshot.
+  pub fn changes_since_snapshot(&self) -> usize {
+    self.changes_since_snapshot
+  }
 
-    /// Deletes old snapshot files, keeping only the N most recent.
-    ///
-    /// # Arguments
-    ///
-    /// * `keep_count` - Number of most recent snapshots to keep
-    /// * `require_uploaded` - If `true`, only delete snapshots marked via `mark_snapshot_uploaded()`.
-    ///   If `false`, delete ALL old snapshots (used by auto-cleanup).
-    ///
-    /// # When to Use Each Mode
-    ///
-    /// **`require_uploaded: false`** (default for auto-cleanup):
-    /// - Prevents unbounded disk growth automatically
-    /// - Safe when snapshots are expendable (can recover from WAL)
-    /// - Used by `auto_cleanup_snapshots` config option
-    ///
-    /// **`require_uploaded: true`** (for R2 backup workflows):
-    /// - Only deletes snapshots that have been successfully uploaded
-    /// - Prevents data loss if upload hooks fail
-    /// - Call after verifying remote backup success
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// # use crdt_lite::persist::{PersistedCRDT, PersistConfig};
-    /// # use std::path::PathBuf;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let mut pcrdt = PersistedCRDT::<String, String, String>::open(
-    /// #     PathBuf::from("./data"), 1, PersistConfig::default())?;
-    /// // Auto-cleanup: delete all old snapshots (default behavior)
-    /// pcrdt.cleanup_old_snapshots(2, false)?;
-    ///
-    /// // R2 workflow: only delete uploaded snapshots
-    /// // (after marking them with mark_snapshot_uploaded)
-    /// pcrdt.cleanup_old_snapshots(2, true)?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn cleanup_old_snapshots(&mut self, keep_count: usize, require_uploaded: bool) -> Result<(), PersistError> {
-        let mut full_snapshots = Vec::new();
-        let mut incremental_snapshots = Vec::new();
+  /// Deletes old snapshot files, keeping only the N most recent.
+  ///
+  /// # Arguments
+  ///
+  /// * `keep_count` - Number of most recent snapshots to keep
+  /// * `require_uploaded` - If `true`, only delete snapshots marked via `mark_snapshot_uploaded()`.
+  ///   If `false`, delete ALL old snapshots (used by auto-cleanup).
+  ///
+  /// # When to Use Each Mode
+  ///
+  /// **`require_uploaded: false`** (default for auto-cleanup):
+  /// - Prevents unbounded disk growth automatically
+  /// - Safe when snapshots are expendable (can recover from WAL)
+  /// - Used by `auto_cleanup_snapshots` config option
+  ///
+  /// **`require_uploaded: true`** (for R2 backup workflows):
+  /// - Only deletes snapshots that have been successfully uploaded
+  /// - Prevents data loss if upload hooks fail
+  /// - Call after verifying remote backup success
+  ///
+  /// # Example
+  ///
+  /// ```no_run
+  /// # use crdt_lite::persist::{PersistedCRDT, PersistConfig};
+  /// # use std::path::PathBuf;
+  /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+  /// # let mut pcrdt = PersistedCRDT::<String, String, String>::open(
+  /// #     PathBuf::from("./data"), 1, PersistConfig::default())?;
+  /// // Auto-cleanup: delete all old snapshots (default behavior)
+  /// pcrdt.cleanup_old_snapshots(2, false)?;
+  ///
+  /// // R2 workflow: only delete uploaded snapshots
+  /// // (after marking them with mark_snapshot_uploaded)
+  /// pcrdt.cleanup_old_snapshots(2, true)?;
+  /// # Ok(())
+  /// # }
+  /// ```
+  pub fn cleanup_old_snapshots(
+    &mut self,
+    keep_count: usize,
+    require_uploaded: bool,
+  ) -> Result<(), PersistError> {
+    let mut full_snapshots = Vec::new();
+    let mut incremental_snapshots = Vec::new();
 
-        // Find all snapshot files (both bincode and MessagePack formats)
-        if let Ok(entries) = std::fs::read_dir(&self.base_dir) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                let filename = entry.file_name();
-                let filename_str = filename.to_string_lossy();
+    // Find all snapshot files (both bincode and MessagePack formats)
+    if let Ok(entries) = std::fs::read_dir(&self.base_dir) {
+      for entry in entries.flatten() {
+        let path = entry.path();
+        let filename = entry.file_name();
+        let filename_str = filename.to_string_lossy();
 
-                // Include based on require_uploaded setting
-                let should_include = if require_uploaded {
-                    self.uploaded_snapshots.contains(&path)
-                } else {
-                    true // Include all snapshots
-                };
+        // Include based on require_uploaded setting
+        let should_include = if require_uploaded {
+          self.uploaded_snapshots.contains(&path)
+        } else {
+          true // Include all snapshots
+        };
 
-                if !should_include {
-                    continue;
-                }
+        if !should_include {
+          continue;
+        }
 
-                // Legacy bincode full snapshots: snapshot_N.bin
-                if filename_str.starts_with("snapshot_") && filename_str.ends_with(".bin") {
-                    if let Some(num_str) = filename_str
-                        .strip_prefix("snapshot_")
-                        .and_then(|s| s.strip_suffix(".bin"))
-                    {
-                        if let Ok(version) = num_str.parse::<u64>() {
-                            full_snapshots.push((version, path));
-                        }
-                    }
-                }
-                // MessagePack full snapshots: snapshot_full_N.msgpack
-                else if filename_str.starts_with("snapshot_full_") && filename_str.ends_with(".msgpack") {
-                    if let Some(num_str) = filename_str
-                        .strip_prefix("snapshot_full_")
-                        .and_then(|s| s.strip_suffix(".msgpack"))
-                    {
-                        if let Ok(version) = num_str.parse::<u64>() {
-                            full_snapshots.push((version, path));
-                        }
-                    }
-                }
-                // MessagePack incremental snapshots: snapshot_incr_N_base_M.msgpack
-                else if filename_str.starts_with("snapshot_incr_") && filename_str.ends_with(".msgpack") {
-                    // Parse: snapshot_incr_VERSION_base_BASEVERSION.msgpack
-                    if let Some(remainder) = filename_str
-                        .strip_prefix("snapshot_incr_")
-                        .and_then(|s| s.strip_suffix(".msgpack"))
-                    {
-                        if let Some((version_str, base_str)) = remainder.split_once("_base_") {
-                            if let (Ok(version), Ok(base_version)) =
-                                (version_str.parse::<u64>(), base_str.parse::<u64>())
-                            {
-                                incremental_snapshots.push((version, base_version, path));
-                            }
-                        }
-                    }
-                }
+        // Legacy bincode full snapshots: snapshot_N.bin
+        if filename_str.starts_with("snapshot_") && filename_str.ends_with(".bin") {
+          if let Some(num_str) = filename_str
+            .strip_prefix("snapshot_")
+            .and_then(|s| s.strip_suffix(".bin"))
+          {
+            if let Ok(version) = num_str.parse::<u64>() {
+              full_snapshots.push((version, path));
             }
+          }
         }
-
-        // Sort full snapshots by version (newest first)
-        full_snapshots.sort_by(|a, b| b.0.cmp(&a.0));
-
-        // Determine which full snapshot versions to keep
-        let keep_versions: std::collections::HashSet<u64> = full_snapshots
-            .iter()
-            .take(keep_count)
-            .map(|(v, _)| *v)
-            .collect();
-
-        // Delete old full snapshots
-        for (version, path) in &full_snapshots {
-            if !keep_versions.contains(version) {
-                if let Err(e) = std::fs::remove_file(path) {
-                    eprintln!("Failed to delete old full snapshot {:?}: {}", path, e);
-                }
-                // Remove from tracking set if present
-                self.uploaded_snapshots.remove(path);
+        // MessagePack full snapshots: snapshot_full_N.msgpack
+        else if filename_str.starts_with("snapshot_full_") && filename_str.ends_with(".msgpack") {
+          if let Some(num_str) = filename_str
+            .strip_prefix("snapshot_full_")
+            .and_then(|s| s.strip_suffix(".msgpack"))
+          {
+            if let Ok(version) = num_str.parse::<u64>() {
+              full_snapshots.push((version, path));
             }
+          }
         }
-
-        // Delete incrementals whose base version is not in keep set (orphaned incrementals)
-        // or whose own version makes them superseded by a newer full snapshot
-        for (version, base_version, path) in &incremental_snapshots {
-            let should_delete = !keep_versions.contains(base_version)  // Base snapshot was deleted
-                || keep_versions.iter().any(|&v| v > *version);        // Superseded by newer full
-
-            if should_delete {
-                if let Err(e) = std::fs::remove_file(path) {
-                    eprintln!("Failed to delete old incremental snapshot {:?}: {}", path, e);
-                }
-                // Remove from tracking set if present
-                self.uploaded_snapshots.remove(path);
+        // MessagePack incremental snapshots: snapshot_incr_N_base_M.msgpack
+        else if filename_str.starts_with("snapshot_incr_") && filename_str.ends_with(".msgpack") {
+          // Parse: snapshot_incr_VERSION_base_BASEVERSION.msgpack
+          if let Some(remainder) = filename_str
+            .strip_prefix("snapshot_incr_")
+            .and_then(|s| s.strip_suffix(".msgpack"))
+          {
+            if let Some((version_str, base_str)) = remainder.split_once("_base_") {
+              if let (Ok(version), Ok(base_version)) =
+                (version_str.parse::<u64>(), base_str.parse::<u64>())
+              {
+                incremental_snapshots.push((version, base_version, path));
+              }
             }
+          }
         }
-
-        Ok(())
+      }
     }
 
-    /// Deletes old WAL segment files, keeping only the N most recent.
-    ///
-    /// # Arguments
-    ///
-    /// * `keep_count` - Number of most recent segments to keep
-    /// * `require_uploaded` - If `true`, only delete segments marked via `mark_wal_segment_uploaded()`.
-    ///   If `false`, delete ALL old segments (used for cleanup after compaction).
-    ///
-    /// # When to Use Each Mode
-    ///
-    /// **`require_uploaded: false`** (for compaction cleanup):
-    /// - Deletes all old WAL segments unconditionally
-    /// - Safe after snapshot creation (snapshot contains all data)
-    /// - Used by `compact_tombstones()` to clean up after compaction
-    ///
-    /// **`require_uploaded: true`** (for R2 backup workflows):
-    /// - Only deletes segments that have been successfully uploaded
-    /// - Prevents data loss if upload hooks fail
-    /// - Call after verifying remote backup success
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// # use crdt_lite::persist::{PersistedCRDT, PersistConfig};
-    /// # use std::path::PathBuf;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let mut pcrdt = PersistedCRDT::<String, String, String>::open(
-    /// #     PathBuf::from("./data"), 1, PersistConfig::default())?;
-    /// // Compaction cleanup: delete all old segments (after snapshot)
-    /// pcrdt.cleanup_old_wal_segments(0, false)?;
-    ///
-    /// // R2 workflow: only delete uploaded segments
-    /// // (after marking them with mark_wal_segment_uploaded)
-    /// pcrdt.cleanup_old_wal_segments(3, true)?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn cleanup_old_wal_segments(&mut self, keep_count: usize, require_uploaded: bool) -> Result<(), PersistError> {
-        let mut segments = Vec::new();
+    // Sort full snapshots by version (newest first)
+    full_snapshots.sort_by(|a, b| b.0.cmp(&a.0));
 
-        // Find all WAL segment files
-        if let Ok(entries) = std::fs::read_dir(&self.base_dir) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                let filename = entry.file_name();
-                let filename_str = filename.to_string_lossy();
-                if filename_str.starts_with("wal_") && filename_str.ends_with(".bin") {
-                    // Include based on require_uploaded setting
-                    let should_include = if require_uploaded {
-                        self.uploaded_wal_segments.contains(&path)
-                    } else {
-                        true // Include all segments
-                    };
+    // Determine which full snapshot versions to keep
+    let keep_versions: std::collections::HashSet<u64> = full_snapshots
+      .iter()
+      .take(keep_count)
+      .map(|(v, _)| *v)
+      .collect();
 
-                    if should_include {
-                        if let Some(num_str) = filename_str
-                            .strip_prefix("wal_")
-                            .and_then(|s| s.strip_suffix(".bin"))
-                        {
-                            if let Ok(segment_num) = num_str.parse::<u64>() {
-                                segments.push((segment_num, path));
-                            }
-                        }
-                    }
-                }
-            }
+    // Delete old full snapshots
+    for (version, path) in &full_snapshots {
+      if !keep_versions.contains(version) {
+        if let Err(e) = std::fs::remove_file(path) {
+          eprintln!("Failed to delete old full snapshot {:?}: {}", path, e);
         }
-
-        // Sort by segment number (newest first)
-        segments.sort_by(|a, b| b.0.cmp(&a.0));
-
-        // Delete all except the most recent N
-        for (_, path) in segments.iter().skip(keep_count) {
-            std::fs::remove_file(path)?;
-            // Remove from tracking set if present
-            self.uploaded_wal_segments.remove(path);
-        }
-
-        Ok(())
+        // Remove from tracking set if present
+        self.uploaded_snapshots.remove(path);
+      }
     }
+
+    // Delete incrementals whose base version is not in keep set (orphaned incrementals)
+    // or whose own version makes them superseded by a newer full snapshot
+    for (version, base_version, path) in &incremental_snapshots {
+      let should_delete = !keep_versions.contains(base_version)  // Base snapshot was deleted
+                || keep_versions.iter().any(|&v| v > *version); // Superseded by newer full
+
+      if should_delete {
+        if let Err(e) = std::fs::remove_file(path) {
+          eprintln!(
+            "Failed to delete old incremental snapshot {:?}: {}",
+            path, e
+          );
+        }
+        // Remove from tracking set if present
+        self.uploaded_snapshots.remove(path);
+      }
+    }
+
+    Ok(())
+  }
+
+  /// Deletes old WAL segment files, keeping only the N most recent.
+  ///
+  /// # Arguments
+  ///
+  /// * `keep_count` - Number of most recent segments to keep
+  /// * `require_uploaded` - If `true`, only delete segments marked via `mark_wal_segment_uploaded()`.
+  ///   If `false`, delete ALL old segments (used for cleanup after compaction).
+  ///
+  /// # When to Use Each Mode
+  ///
+  /// **`require_uploaded: false`** (for compaction cleanup):
+  /// - Deletes all old WAL segments unconditionally
+  /// - Safe after snapshot creation (snapshot contains all data)
+  /// - Used by `compact_tombstones()` to clean up after compaction
+  ///
+  /// **`require_uploaded: true`** (for R2 backup workflows):
+  /// - Only deletes segments that have been successfully uploaded
+  /// - Prevents data loss if upload hooks fail
+  /// - Call after verifying remote backup success
+  ///
+  /// # Example
+  ///
+  /// ```no_run
+  /// # use crdt_lite::persist::{PersistedCRDT, PersistConfig};
+  /// # use std::path::PathBuf;
+  /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+  /// # let mut pcrdt = PersistedCRDT::<String, String, String>::open(
+  /// #     PathBuf::from("./data"), 1, PersistConfig::default())?;
+  /// // Compaction cleanup: delete all old segments (after snapshot)
+  /// pcrdt.cleanup_old_wal_segments(0, false)?;
+  ///
+  /// // R2 workflow: only delete uploaded segments
+  /// // (after marking them with mark_wal_segment_uploaded)
+  /// pcrdt.cleanup_old_wal_segments(3, true)?;
+  /// # Ok(())
+  /// # }
+  /// ```
+  pub fn cleanup_old_wal_segments(
+    &mut self,
+    keep_count: usize,
+    require_uploaded: bool,
+  ) -> Result<(), PersistError> {
+    let mut segments = Vec::new();
+
+    // Find all WAL segment files
+    if let Ok(entries) = std::fs::read_dir(&self.base_dir) {
+      for entry in entries.flatten() {
+        let path = entry.path();
+        let filename = entry.file_name();
+        let filename_str = filename.to_string_lossy();
+        if filename_str.starts_with("wal_") && filename_str.ends_with(".bin") {
+          // Include based on require_uploaded setting
+          let should_include = if require_uploaded {
+            self.uploaded_wal_segments.contains(&path)
+          } else {
+            true // Include all segments
+          };
+
+          if should_include {
+            if let Some(num_str) = filename_str
+              .strip_prefix("wal_")
+              .and_then(|s| s.strip_suffix(".bin"))
+            {
+              if let Ok(segment_num) = num_str.parse::<u64>() {
+                segments.push((segment_num, path));
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Sort by segment number (newest first)
+    segments.sort_by(|a, b| b.0.cmp(&a.0));
+
+    // Delete all except the most recent N
+    for (_, path) in segments.iter().skip(keep_count) {
+      std::fs::remove_file(path)?;
+      // Remove from tracking set if present
+      self.uploaded_wal_segments.remove(path);
+    }
+
+    Ok(())
+  }
 }
 
 // Private implementation methods
 impl<K, C, V> PersistedCRDT<K, C, V>
 where
-    K: Ord + Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
-    C: Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
-    V: Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+  K: Ord + Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+  C: Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+  V: Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
 {
-    /// Discovers all snapshots in the base directory and returns the latest full snapshot
-    /// and any incremental snapshots that build on it.
+  /// Discovers all snapshots in the base directory and returns the latest full snapshot
+  /// and any incremental snapshots that build on it.
+  #[cfg(feature = "msgpack")]
+  #[allow(clippy::type_complexity)]
+  fn discover_snapshots(
+    base_dir: &PathBuf,
+  ) -> Result<(Option<(PathBuf, u64)>, Vec<(PathBuf, u64)>), PersistError> {
+    let mut full_snapshots: Vec<(PathBuf, u64)> = Vec::new();
+    let mut incremental_snapshots: Vec<(PathBuf, u64, u64)> = Vec::new(); // (path, version, base_version)
+
+    if let Ok(entries) = std::fs::read_dir(base_dir) {
+      for entry in entries.flatten() {
+        let path = entry.path();
+        let filename = entry.file_name();
+        let filename_str = filename.to_string_lossy();
+
+        // Parse full snapshots: snapshot_full_000001.msgpack
+        if filename_str.starts_with("snapshot_full_") && filename_str.ends_with(".msgpack") {
+          if let Some(version_str) = filename_str
+            .strip_prefix("snapshot_full_")
+            .and_then(|s| s.strip_suffix(".msgpack"))
+          {
+            if let Ok(version) = version_str.parse::<u64>() {
+              full_snapshots.push((path.clone(), version));
+            }
+          }
+        }
+
+        // Parse incremental snapshots: snapshot_incr_000002_base_000001.msgpack
+        if filename_str.starts_with("snapshot_incr_") && filename_str.ends_with(".msgpack") {
+          let parts: Vec<&str> = filename_str.split('_').collect();
+          if parts.len() >= 5 {
+            // ["snapshot", "incr", "000002", "base", "000001.msgpack"]
+            if let (Ok(version), Some(base_str)) =
+              (parts[2].parse::<u64>(), parts[4].strip_suffix(".msgpack"))
+            {
+              if let Ok(base_version) = base_str.parse::<u64>() {
+                incremental_snapshots.push((path.clone(), version, base_version));
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Find the latest full snapshot
+    full_snapshots.sort_by_key(|(_, version)| *version);
+    let latest_full = full_snapshots.last().cloned();
+
+    // If we have a latest full, find all incrementals that build on it
+    let relevant_incrementals = if let Some((_, base_version)) = latest_full {
+      let mut relevant: Vec<(PathBuf, u64)> = incremental_snapshots
+        .into_iter()
+        .filter(|(_, _, base)| *base == base_version)
+        .map(|(path, version, _)| (path, version))
+        .collect();
+      relevant.sort_by_key(|(_, version)| *version);
+
+      // Validate incremental chain integrity
+      if !relevant.is_empty() {
+        let versions: Vec<u64> = relevant.iter().map(|(_, v)| *v).collect();
+
+        // Check 1: Incrementals should start immediately after base
+        if versions[0] != base_version + 1 {
+          eprintln!(
+            "WARNING: Incremental chain gap detected. Base version: {}, first incremental: {}",
+            base_version, versions[0]
+          );
+        }
+
+        // Check 2: Incrementals should be contiguous (no gaps)
+        for window in versions.windows(2) {
+          if window[1] != window[0] + 1 {
+            eprintln!(
+              "WARNING: Non-contiguous incremental snapshots detected: {} -> {}",
+              window[0], window[1]
+            );
+          }
+        }
+      }
+
+      relevant
+    } else {
+      Vec::new()
+    };
+
+    Ok((latest_full, relevant_incrementals))
+  }
+
+  /// Recovers CRDT state from disk: loads snapshot + replays WAL files.
+  #[allow(clippy::type_complexity)]
+  fn recover(
+    base_dir: &PathBuf,
+    node_id: NodeId,
+  ) -> Result<(CRDT<K, C, V>, WalWriter<K, C, V>, usize, u64), PersistError> {
+    let mut max_snapshot_version = 0u64;
+    let mut crdt = None;
+
+    // First, try to load MessagePack snapshots (full + incrementals)
     #[cfg(feature = "msgpack")]
-    #[allow(clippy::type_complexity)]
-    fn discover_snapshots(
-        base_dir: &PathBuf,
-    ) -> Result<(Option<(PathBuf, u64)>, Vec<(PathBuf, u64)>), PersistError> {
-        let mut full_snapshots: Vec<(PathBuf, u64)> = Vec::new();
-        let mut incremental_snapshots: Vec<(PathBuf, u64, u64)> = Vec::new(); // (path, version, base_version)
+    {
+      let (latest_full, incrementals) = Self::discover_snapshots(base_dir)?;
 
-        if let Ok(entries) = std::fs::read_dir(base_dir) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                let filename = entry.file_name();
-                let filename_str = filename.to_string_lossy();
+      if let Some((full_path, full_version)) = latest_full {
+        // Load full snapshot
+        let bytes = std::fs::read(&full_path)?;
 
-                // Parse full snapshots: snapshot_full_000001.msgpack
-                if filename_str.starts_with("snapshot_full_") && filename_str.ends_with(".msgpack") {
-                    if let Some(version_str) = filename_str
-                        .strip_prefix("snapshot_full_")
-                        .and_then(|s| s.strip_suffix(".msgpack"))
-                    {
-                        if let Ok(version) = version_str.parse::<u64>() {
-                            full_snapshots.push((path.clone(), version));
-                        }
-                    }
-                }
-
-                // Parse incremental snapshots: snapshot_incr_000002_base_000001.msgpack
-                if filename_str.starts_with("snapshot_incr_") && filename_str.ends_with(".msgpack") {
-                    let parts: Vec<&str> = filename_str.split('_').collect();
-                    if parts.len() >= 5 {
-                        // ["snapshot", "incr", "000002", "base", "000001.msgpack"]
-                        if let (Ok(version), Some(base_str)) = (
-                            parts[2].parse::<u64>(),
-                            parts[4].strip_suffix(".msgpack"),
-                        ) {
-                            if let Ok(base_version) = base_str.parse::<u64>() {
-                                incremental_snapshots.push((path.clone(), version, base_version));
-                            }
-                        }
-                    }
-                }
+        // Decompress if needed
+        let decompressed = {
+          #[cfg(feature = "compression")]
+          {
+            // Try to detect if data is compressed by checking for zstd magic bytes
+            if bytes.len() >= 4 && &bytes[0..4] == b"\x28\xb5\x2f\xfd" {
+              zstd::decode_all(&bytes[..]).map_err(PersistError::Compression)?
+            } else {
+              bytes
             }
-        }
-
-        // Find the latest full snapshot
-        full_snapshots.sort_by_key(|(_, version)| *version);
-        let latest_full = full_snapshots.last().cloned();
-
-        // If we have a latest full, find all incrementals that build on it
-        let relevant_incrementals = if let Some((_, base_version)) = latest_full {
-            let mut relevant: Vec<(PathBuf, u64)> = incremental_snapshots
-                .into_iter()
-                .filter(|(_, _, base)| *base == base_version)
-                .map(|(path, version, _)| (path, version))
-                .collect();
-            relevant.sort_by_key(|(_, version)| *version);
-
-            // Validate incremental chain integrity
-            if !relevant.is_empty() {
-                let versions: Vec<u64> = relevant.iter().map(|(_, v)| *v).collect();
-
-                // Check 1: Incrementals should start immediately after base
-                if versions[0] != base_version + 1 {
-                    eprintln!(
-                        "WARNING: Incremental chain gap detected. Base version: {}, first incremental: {}",
-                        base_version, versions[0]
-                    );
-                }
-
-                // Check 2: Incrementals should be contiguous (no gaps)
-                for window in versions.windows(2) {
-                    if window[1] != window[0] + 1 {
-                        eprintln!(
-                            "WARNING: Non-contiguous incremental snapshots detected: {} -> {}",
-                            window[0], window[1]
-                        );
-                    }
-                }
-            }
-
-            relevant
-        } else {
-            Vec::new()
+          }
+          #[cfg(not(feature = "compression"))]
+          {
+            bytes
+          }
         };
 
-        Ok((latest_full, relevant_incrementals))
-    }
+        // Parse the combined format: metadata_len (u32) + metadata + crdt_bytes
+        if decompressed.len() >= 4 {
+          let metadata_len = u32::from_le_bytes([
+            decompressed[0],
+            decompressed[1],
+            decompressed[2],
+            decompressed[3],
+          ]) as usize;
 
-    /// Recovers CRDT state from disk: loads snapshot + replays WAL files.
-    #[allow(clippy::type_complexity)]
-    fn recover(
-        base_dir: &PathBuf,
-        node_id: NodeId,
-    ) -> Result<(CRDT<K, C, V>, WalWriter<K, C, V>, usize, u64), PersistError> {
-        let mut max_snapshot_version = 0u64;
-        let mut crdt = None;
+          if decompressed.len() >= 4 + metadata_len {
+            let _metadata: SnapshotMetadata =
+              rmp_serde::from_slice(&decompressed[4..4 + metadata_len])?;
+            let crdt_bytes = &decompressed[4 + metadata_len..];
+            let mut loaded_crdt = CRDT::from_msgpack_bytes(crdt_bytes)?;
 
-        // First, try to load MessagePack snapshots (full + incrementals)
-        #[cfg(feature = "msgpack")]
-        {
-            let (latest_full, incrementals) = Self::discover_snapshots(base_dir)?;
-
-            if let Some((full_path, full_version)) = latest_full {
-                // Load full snapshot
-                let bytes = std::fs::read(&full_path)?;
-
-                // Decompress if needed
-                let decompressed = {
-                    #[cfg(feature = "compression")]
-                    {
-                        // Try to detect if data is compressed by checking for zstd magic bytes
-                        if bytes.len() >= 4 && &bytes[0..4] == b"\x28\xb5\x2f\xfd" {
-                            zstd::decode_all(&bytes[..]).map_err(PersistError::Compression)?
-                        } else {
-                            bytes
-                        }
-                    }
-                    #[cfg(not(feature = "compression"))]
-                    {
-                        bytes
-                    }
-                };
-
-                // Parse the combined format: metadata_len (u32) + metadata + crdt_bytes
-                if decompressed.len() >= 4 {
-                    let metadata_len = u32::from_le_bytes([
-                        decompressed[0],
-                        decompressed[1],
-                        decompressed[2],
-                        decompressed[3],
-                    ]) as usize;
-
-                    if decompressed.len() >= 4 + metadata_len {
-                        let _metadata: SnapshotMetadata =
-                            rmp_serde::from_slice(&decompressed[4..4 + metadata_len])?;
-                        let crdt_bytes = &decompressed[4 + metadata_len..];
-                        let mut loaded_crdt = CRDT::from_msgpack_bytes(crdt_bytes)?;
-
-                        // Apply incremental snapshots in order
-                        // Note: Each incremental is loaded entirely into memory before applying.
-                        // This is acceptable because incrementals should be small (default config
-                        // creates full snapshot every 10 incrementals). If memory is constrained,
-                        // reduce full_snapshot_interval or snapshot_threshold.
-                        for (incr_path, _) in incrementals {
-                            let incr_bytes = std::fs::read(&incr_path)?;
-                            let incr_decompressed = {
-                                #[cfg(feature = "compression")]
-                                {
-                                    // Try to detect if data is compressed by checking for zstd magic bytes
-                                    if incr_bytes.len() >= 4 && &incr_bytes[0..4] == b"\x28\xb5\x2f\xfd" {
-                                        zstd::decode_all(&incr_bytes[..]).map_err(PersistError::Compression)?
-                                    } else {
-                                        incr_bytes
-                                    }
-                                }
-                                #[cfg(not(feature = "compression"))]
-                                {
-                                    incr_bytes
-                                }
-                            };
-
-                            let incremental: IncrementalSnapshot<K, C, V> =
-                                rmp_serde::from_slice(&incr_decompressed)?;
-
-                            // Use merge_changes to apply incremental updates
-                            // Convert changed records to changes
-                            let mut changes = Vec::new();
-                            for (key, record) in incremental.changed_records {
-                                for (col_name, value) in record.fields {
-                                    if let Some(col_version) = record.column_versions.get(&col_name) {
-                                        changes.push(Change {
-                                            record_id: key.clone(),
-                                            col_name: Some(col_name),
-                                            value: Some(value),
-                                            col_version: col_version.col_version,
-                                            db_version: col_version.db_version,
-                                            node_id: col_version.node_id,
-                                            local_db_version: col_version.local_db_version,
-                                            flags: 0,
-                                        });
-                                    }
-                                }
-                            }
-
-                            // Add tombstone changes
-                            for (key, tombstone) in incremental.new_tombstones {
-                                changes.push(Change {
-                                    record_id: key,
-                                    col_name: None,
-                                    value: None,
-                                    col_version: 0,
-                                    db_version: tombstone.db_version,
-                                    node_id: tombstone.node_id,
-                                    local_db_version: tombstone.local_db_version,
-                                    flags: 1, // Tombstone flag
-                                });
-                            }
-
-                            // Apply changes using merge_changes
-                            loaded_crdt.merge_changes(changes, &DefaultMergeRule);
-                        }
-
-                        max_snapshot_version = full_version;
-                        crdt = Some(loaded_crdt);
-                    }
-                }
-            }
-        }
-
-        // Fallback to bincode snapshots if no MessagePack found
-        if crdt.is_none() {
-            if let Ok(entries) = std::fs::read_dir(base_dir) {
-                for entry in entries.flatten() {
-                    let filename = entry.file_name();
-                    let filename_str = filename.to_string_lossy();
-                    if filename_str.starts_with("snapshot_") && filename_str.ends_with(".bin") {
-                        // Parse version number from filename (snapshot_000001.bin)
-                        if let Some(num_str) = filename_str
-                            .strip_prefix("snapshot_")
-                            .and_then(|s| s.strip_suffix(".bin"))
-                        {
-                            if let Ok(num) = num_str.parse::<u64>() {
-                                if num > max_snapshot_version {
-                                    max_snapshot_version = num;
-                                    let bytes = std::fs::read(entry.path())?;
-                                    crdt = Some(CRDT::from_bytes(&bytes).map_err(PersistError::BincodeDecode)?);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // Create new CRDT if no snapshot found
-        let crdt = crdt.unwrap_or_else(|| CRDT::new(node_id, None));
-
-        // Create WAL writer
-        let wal = WalWriter::new(base_dir.clone())?;
-
-        // Replay all WAL files
-        let (recovered_crdt, change_count) = Self::replay_wal(crdt, base_dir)?;
-
-        Ok((recovered_crdt, wal, change_count, max_snapshot_version))
-    }
-
-    /// Replays all WAL files on top of the base CRDT state.
-    fn replay_wal(
-        mut crdt: CRDT<K, C, V>,
-        base_dir: &PathBuf,
-    ) -> Result<(CRDT<K, C, V>, usize), PersistError> {
-        let mut total_changes = 0;
-
-        // Find all WAL files (wal_*.bin)
-        let mut wal_files: Vec<_> = std::fs::read_dir(base_dir)?
-            .filter_map(|entry| entry.ok())
-            .filter(|entry| {
-                entry
-                    .file_name()
-                    .to_string_lossy()
-                    .starts_with("wal_")
-                    && entry.file_name().to_string_lossy().ends_with(".bin")
-            })
-            .collect();
-
-        // Sort by segment number (parse numerically for correctness)
-        wal_files.sort_by_key(|entry| {
-            entry
-                .file_name()
-                .to_string_lossy()
-                .strip_prefix("wal_")
-                .and_then(|s| s.strip_suffix(".bin"))
-                .and_then(|num| num.parse::<u64>().ok())
-                .unwrap_or(0)
-        });
-
-        // Replay each WAL file
-        for entry in wal_files {
-            let changes = wal::read_wal_file(&entry.path())?;
-            total_changes += changes.len();
-            crdt.merge_changes(changes, &DefaultMergeRule);
-        }
-
-        Ok((crdt, total_changes))
-    }
-
-    /// Compresses data using zstd if compression is enabled.
-    #[cfg(feature = "compression")]
-    fn maybe_compress(&self, data: Vec<u8>) -> Result<Vec<u8>, PersistError> {
-        if self.config.enable_compression {
-            zstd::encode_all(&data[..], 3).map_err(PersistError::Compression)
-        } else {
-            Ok(data)
-        }
-    }
-
-    #[cfg(not(feature = "compression"))]
-    fn maybe_compress(&self, data: Vec<u8>) -> Result<Vec<u8>, PersistError> {
-        Ok(data)
-    }
-
-    /// Decompresses data using zstd if it was compressed.
-    #[cfg(feature = "compression")]
-    #[allow(dead_code)]
-    fn maybe_decompress(&self, data: Vec<u8>) -> Result<Vec<u8>, PersistError> {
-        if self.config.enable_compression {
-            zstd::decode_all(&data[..]).map_err(PersistError::Compression)
-        } else {
-            Ok(data)
-        }
-    }
-
-    #[cfg(not(feature = "compression"))]
-    #[allow(dead_code)]
-    fn maybe_decompress(&self, data: Vec<u8>) -> Result<Vec<u8>, PersistError> {
-        Ok(data)
-    }
-
-    /// Determines whether to create a full or incremental snapshot.
-    fn should_create_full_snapshot(&self) -> bool {
-        // Always create full snapshot if:
-        // 1. Incremental snapshots are disabled
-        // 2. Using bincode format (doesn't support incrementals)
-        // 3. No previous full snapshot exists (first snapshot must be full)
-        // 4. Reached the full snapshot interval
-        !self.config.enable_incremental_snapshots
-            || self.config.snapshot_format == SnapshotFormat::Bincode
-            || self.last_full_snapshot_version == 0
-            || self.incremental_snapshot_count >= self.config.full_snapshot_interval
-    }
-
-    /// Creates a full snapshot using MessagePack format.
-    #[cfg(feature = "msgpack")]
-    fn create_full_snapshot_msgpack(&mut self) -> Result<PathBuf, PersistError> {
-        use std::io::Write;
-
-        // Increment snapshot version
-        self.snapshot_version += 1;
-
-        let metadata = SnapshotMetadata {
-            snapshot_type: SnapshotType::Full,
-            version: self.crdt.get_clock().current_time(),
-            format: SnapshotFormat::MessagePack,
-            created_at: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or(std::time::Duration::from_secs(0))
-                .as_secs(),
-        };
-
-        // Serialize CRDT using MessagePack (via to_msgpack_bytes which already exists)
-        let crdt_bytes = self.crdt.to_msgpack_bytes()
-            .map_err(|e| {
-                eprintln!("Failed to serialize CRDT for full snapshot: {}", e);
-                e
-            })?;
-
-        // Create a simpler snapshot structure with just metadata + crdt bytes
-        // We'll serialize them separately and combine
-        let metadata_bytes = rmp_serde::to_vec(&metadata)
-            .map_err(|e| {
-                eprintln!("Failed to serialize snapshot metadata: {}", e);
-                PersistError::MsgpackEncode(e)
-            })?;
-
-        // Combine: metadata_len (u32) + metadata + crdt_bytes
-        let mut combined = Vec::new();
-        combined.extend_from_slice(&(metadata_bytes.len() as u32).to_le_bytes());
-        combined.extend_from_slice(&metadata_bytes);
-        combined.extend_from_slice(&crdt_bytes);
-
-        let compressed = self.maybe_compress(combined)?;
-
-        // Write to file
-        let snapshot_path = self.base_dir.join(format!(
-            "snapshot_full_{:06}.msgpack",
-            self.snapshot_version
-        ));
-
-        {
-            let mut file = std::fs::File::create(&snapshot_path)?;
-            file.write_all(&compressed)?;
-            file.sync_all()?;
-            drop(file);
-        }
-
-        #[cfg(target_os = "windows")]
-        std::thread::sleep(std::time::Duration::from_millis(10));
-
-        // Update tracking
-        self.incremental_snapshot_count = 0;
-        self.last_full_snapshot_version = self.snapshot_version;
-        self.last_snapshot_crdt_version = self.crdt.get_clock().current_time();
-
-        Ok(snapshot_path)
-    }
-
-    /// Creates an incremental snapshot using MessagePack format.
-    #[cfg(feature = "msgpack")]
-    fn create_incremental_snapshot_msgpack(&mut self) -> Result<PathBuf, PersistError> {
-        use std::io::Write;
-
-        // Get changes since last snapshot
-        let (changed_records, new_tombstones) =
-            self.crdt.get_changed_since(self.last_snapshot_crdt_version);
-
-        // Skip creating snapshot if no changes (configurable)
-        // Empty snapshots provide no value since WAL contains all operations anyway.
-        // Only create empty snapshots if explicitly disabled via config (for testing).
-        //
-        // NOTE: When skipped, returns empty PathBuf and snapshot hooks are NOT called.
-        // This is intentional - backup systems shouldn't be notified of non-existent files.
-        // If your backup workflow requires periodic notifications even without changes,
-        // set skip_empty_incrementals = false (not recommended).
-        if self.config.skip_empty_incrementals
-            && changed_records.is_empty()
-            && new_tombstones.is_empty()
-        {
-            // Update last_snapshot_time to prevent repeated time-based triggers
-            // (prevents tight loop when no changes but snapshot_interval_secs is set)
-            self.last_snapshot_time = std::time::Instant::now();
-            return Ok(PathBuf::new()); // Return empty path to indicate skipped
-        }
-
-        // Increment snapshot version
-        self.snapshot_version += 1;
-
-        let metadata = SnapshotMetadata {
-            snapshot_type: SnapshotType::Incremental {
-                base_version: self.last_full_snapshot_version,
-            },
-            version: self.crdt.get_clock().current_time(),
-            format: SnapshotFormat::MessagePack,
-            created_at: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or(std::time::Duration::from_secs(0))
-                .as_secs(),
-        };
-
-        let incremental_snapshot = IncrementalSnapshot {
-            metadata,
-            changed_records,
-            new_tombstones,
-            clock_version: self.crdt.get_clock().current_time(),
-        };
-
-        // Serialize to MessagePack
-        let bytes = rmp_serde::to_vec(&incremental_snapshot)
-            .map_err(|e| {
-                eprintln!("Failed to serialize incremental snapshot: {} records, {} tombstones",
-                    incremental_snapshot.changed_records.len(),
-                    incremental_snapshot.new_tombstones.len());
-                eprintln!("Serialization error: {}", e);
-                PersistError::MsgpackEncode(e)
-            })?;
-        let compressed = self.maybe_compress(bytes)?;
-
-        // Write to file
-        let snapshot_path = self.base_dir.join(format!(
-            "snapshot_incr_{:06}_base_{:06}.msgpack",
-            self.snapshot_version, self.last_full_snapshot_version
-        ));
-
-        {
-            let mut file = std::fs::File::create(&snapshot_path)?;
-            file.write_all(&compressed)?;
-            file.sync_all()?;
-            drop(file);
-        }
-
-        #[cfg(target_os = "windows")]
-        std::thread::sleep(std::time::Duration::from_millis(10));
-
-        // Update tracking
-        self.incremental_snapshot_count += 1;
-        self.last_snapshot_crdt_version = self.crdt.get_clock().current_time();
-
-        Ok(snapshot_path)
-    }
-
-    /// Creates a snapshot of the current CRDT state and rotates the WAL.
-    fn create_snapshot(&mut self) -> Result<(), PersistError> {
-        use std::io::Write;
-
-        let snapshot_path = match self.config.snapshot_format {
-            SnapshotFormat::Bincode => {
-                // Legacy bincode format (no incrementals)
-                let bytes = self.crdt.to_bytes().map_err(PersistError::BincodeEncode)?;
-
-                self.snapshot_version += 1;
-                let path = self
-                    .base_dir
-                    .join(format!("snapshot_{:06}.bin", self.snapshot_version));
-
+            // Apply incremental snapshots in order
+            // Note: Each incremental is loaded entirely into memory before applying.
+            // This is acceptable because incrementals should be small (default config
+            // creates full snapshot every 10 incrementals). If memory is constrained,
+            // reduce full_snapshot_interval or snapshot_threshold.
+            for (incr_path, _) in incrementals {
+              let incr_bytes = std::fs::read(&incr_path)?;
+              let incr_decompressed = {
+                #[cfg(feature = "compression")]
                 {
-                    let mut file = std::fs::File::create(&path)?;
-                    file.write_all(&bytes)?;
-                    file.sync_all()?;
-                    drop(file);
+                  // Try to detect if data is compressed by checking for zstd magic bytes
+                  if incr_bytes.len() >= 4 && &incr_bytes[0..4] == b"\x28\xb5\x2f\xfd" {
+                    zstd::decode_all(&incr_bytes[..]).map_err(PersistError::Compression)?
+                  } else {
+                    incr_bytes
+                  }
                 }
-
-                #[cfg(target_os = "windows")]
-                std::thread::sleep(std::time::Duration::from_millis(10));
-
-                path
-            }
-            #[cfg(feature = "msgpack")]
-            SnapshotFormat::MessagePack => {
-                if self.should_create_full_snapshot() {
-                    self.create_full_snapshot_msgpack()?
-                } else {
-                    self.create_incremental_snapshot_msgpack()?
+                #[cfg(not(feature = "compression"))]
+                {
+                  incr_bytes
                 }
-            }
-            #[cfg(not(feature = "msgpack"))]
-            SnapshotFormat::MessagePack => {
-                return Err(PersistError::UnsupportedFeature(
-                    "MessagePack format requires 'msgpack' feature".to_string(),
-                ));
-            }
-        };
+              };
 
-        // Call snapshot hooks (file is now sealed and immutable)
-        // Skip calling hooks if snapshot was skipped (empty path)
-        if !snapshot_path.as_os_str().is_empty() {
-            let db_version = self.crdt.get_clock().current_time();
-            for hook in &self.snapshot_hooks {
-                hook.on_snapshot(&snapshot_path, db_version);
+              let incremental: IncrementalSnapshot<K, C, V> =
+                rmp_serde::from_slice(&incr_decompressed)?;
+
+              // Use merge_changes to apply incremental updates
+              // Convert changed records to changes
+              let mut changes = Vec::new();
+              for (key, record) in incremental.changed_records {
+                for (col_name, value) in record.fields {
+                  if let Some(col_version) = record.column_versions.get(&col_name) {
+                    changes.push(Change {
+                      record_id: key.clone(),
+                      col_name: Some(col_name),
+                      value: Some(value),
+                      col_version: col_version.col_version,
+                      db_version: col_version.db_version,
+                      node_id: col_version.node_id,
+                      local_db_version: col_version.local_db_version,
+                      flags: 0,
+                    });
+                  }
+                }
+              }
+
+              // Add tombstone changes
+              for (key, tombstone) in incremental.new_tombstones {
+                changes.push(Change {
+                  record_id: key,
+                  col_name: None,
+                  value: None,
+                  col_version: 0,
+                  db_version: tombstone.db_version,
+                  node_id: tombstone.node_id,
+                  local_db_version: tombstone.local_db_version,
+                  flags: 1, // Tombstone flag
+                });
+              }
+
+              // Apply changes using merge_changes
+              loaded_crdt.merge_changes(changes, &DefaultMergeRule);
             }
+
+            max_snapshot_version = full_version;
+            crdt = Some(loaded_crdt);
+          }
         }
-
-        // Rotate WAL (seals old segments, calls hooks, starts new segment)
-        let _ = self.wal.rotate(&self.base_dir, &self.wal_segment_hooks)?;
-
-        // Auto-cleanup old snapshots if configured
-        if let Some(keep_count) = self.config.auto_cleanup_snapshots {
-            let _ = self.cleanup_old_snapshots(keep_count, false);
-        }
-
-        // Reset counter and timer
-        self.changes_since_snapshot = 0;
-        self.last_snapshot_time = Instant::now();
-
-        Ok(())
+      }
     }
 
-    /// Checks if automatic snapshot threshold is reached and creates snapshot if needed.
-    /// Snapshots are triggered by either:
-    /// - Change count reaching snapshot_threshold (default: 1000)
-    /// - Time elapsed reaching snapshot_interval_secs (default: 300 = 5 minutes)
-    fn check_auto_snapshot(&mut self) -> Result<(), PersistError> {
-        let should_snapshot =
+    // Fallback to bincode snapshots if no MessagePack found
+    if crdt.is_none() {
+      if let Ok(entries) = std::fs::read_dir(base_dir) {
+        for entry in entries.flatten() {
+          let filename = entry.file_name();
+          let filename_str = filename.to_string_lossy();
+          if filename_str.starts_with("snapshot_") && filename_str.ends_with(".bin") {
+            // Parse version number from filename (snapshot_000001.bin)
+            if let Some(num_str) = filename_str
+              .strip_prefix("snapshot_")
+              .and_then(|s| s.strip_suffix(".bin"))
+            {
+              if let Ok(num) = num_str.parse::<u64>() {
+                if num > max_snapshot_version {
+                  max_snapshot_version = num;
+                  let bytes = std::fs::read(entry.path())?;
+                  crdt = Some(CRDT::from_bytes(&bytes).map_err(PersistError::BincodeDecode)?);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Create new CRDT if no snapshot found
+    let crdt = crdt.unwrap_or_else(|| CRDT::new(node_id, None));
+
+    // Create WAL writer
+    let wal = WalWriter::new(base_dir.clone())?;
+
+    // Replay all WAL files
+    let (recovered_crdt, change_count) = Self::replay_wal(crdt, base_dir)?;
+
+    Ok((recovered_crdt, wal, change_count, max_snapshot_version))
+  }
+
+  /// Replays all WAL files on top of the base CRDT state.
+  fn replay_wal(
+    mut crdt: CRDT<K, C, V>,
+    base_dir: &PathBuf,
+  ) -> Result<(CRDT<K, C, V>, usize), PersistError> {
+    let mut total_changes = 0;
+
+    // Find all WAL files (wal_*.bin)
+    let mut wal_files: Vec<_> = std::fs::read_dir(base_dir)?
+      .filter_map(|entry| entry.ok())
+      .filter(|entry| {
+        entry.file_name().to_string_lossy().starts_with("wal_")
+          && entry.file_name().to_string_lossy().ends_with(".bin")
+      })
+      .collect();
+
+    // Sort by segment number (parse numerically for correctness)
+    wal_files.sort_by_key(|entry| {
+      entry
+        .file_name()
+        .to_string_lossy()
+        .strip_prefix("wal_")
+        .and_then(|s| s.strip_suffix(".bin"))
+        .and_then(|num| num.parse::<u64>().ok())
+        .unwrap_or(0)
+    });
+
+    // Replay each WAL file
+    for entry in wal_files {
+      let changes = wal::read_wal_file(&entry.path())?;
+      total_changes += changes.len();
+      crdt.merge_changes(changes, &DefaultMergeRule);
+    }
+
+    Ok((crdt, total_changes))
+  }
+
+  /// Compresses data using zstd if compression is enabled.
+  #[cfg(feature = "compression")]
+  fn maybe_compress(&self, data: Vec<u8>) -> Result<Vec<u8>, PersistError> {
+    if self.config.enable_compression {
+      zstd::encode_all(&data[..], 3).map_err(PersistError::Compression)
+    } else {
+      Ok(data)
+    }
+  }
+
+  #[cfg(not(feature = "compression"))]
+  fn maybe_compress(&self, data: Vec<u8>) -> Result<Vec<u8>, PersistError> {
+    Ok(data)
+  }
+
+  /// Decompresses data using zstd if it was compressed.
+  #[cfg(feature = "compression")]
+  #[allow(dead_code)]
+  fn maybe_decompress(&self, data: Vec<u8>) -> Result<Vec<u8>, PersistError> {
+    if self.config.enable_compression {
+      zstd::decode_all(&data[..]).map_err(PersistError::Compression)
+    } else {
+      Ok(data)
+    }
+  }
+
+  #[cfg(not(feature = "compression"))]
+  #[allow(dead_code)]
+  fn maybe_decompress(&self, data: Vec<u8>) -> Result<Vec<u8>, PersistError> {
+    Ok(data)
+  }
+
+  /// Determines whether to create a full or incremental snapshot.
+  fn should_create_full_snapshot(&self) -> bool {
+    // Always create full snapshot if:
+    // 1. Incremental snapshots are disabled
+    // 2. Using bincode format (doesn't support incrementals)
+    // 3. No previous full snapshot exists (first snapshot must be full)
+    // 4. Reached the full snapshot interval
+    !self.config.enable_incremental_snapshots
+      || self.config.snapshot_format == SnapshotFormat::Bincode
+      || self.last_full_snapshot_version == 0
+      || self.incremental_snapshot_count >= self.config.full_snapshot_interval
+  }
+
+  /// Creates a full snapshot using MessagePack format.
+  #[cfg(feature = "msgpack")]
+  fn create_full_snapshot_msgpack(&mut self) -> Result<PathBuf, PersistError> {
+    use std::io::Write;
+
+    // Increment snapshot version
+    self.snapshot_version += 1;
+
+    let metadata = SnapshotMetadata {
+      snapshot_type: SnapshotType::Full,
+      version: self.crdt.get_clock().current_time(),
+      format: SnapshotFormat::MessagePack,
+      created_at: std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or(std::time::Duration::from_secs(0))
+        .as_secs(),
+    };
+
+    // Serialize CRDT using MessagePack (via to_msgpack_bytes which already exists)
+    let crdt_bytes = self.crdt.to_msgpack_bytes().map_err(|e| {
+      eprintln!("Failed to serialize CRDT for full snapshot: {}", e);
+      e
+    })?;
+
+    // Create a simpler snapshot structure with just metadata + crdt bytes
+    // We'll serialize them separately and combine
+    let metadata_bytes = rmp_serde::to_vec(&metadata).map_err(|e| {
+      eprintln!("Failed to serialize snapshot metadata: {}", e);
+      PersistError::MsgpackEncode(e)
+    })?;
+
+    // Combine: metadata_len (u32) + metadata + crdt_bytes
+    let mut combined = Vec::new();
+    combined.extend_from_slice(&(metadata_bytes.len() as u32).to_le_bytes());
+    combined.extend_from_slice(&metadata_bytes);
+    combined.extend_from_slice(&crdt_bytes);
+
+    let compressed = self.maybe_compress(combined)?;
+
+    // Write to file
+    let snapshot_path = self.base_dir.join(format!(
+      "snapshot_full_{:06}.msgpack",
+      self.snapshot_version
+    ));
+
+    {
+      let mut file = std::fs::File::create(&snapshot_path)?;
+      file.write_all(&compressed)?;
+      file.sync_all()?;
+      drop(file);
+    }
+
+    #[cfg(target_os = "windows")]
+    std::thread::sleep(std::time::Duration::from_millis(10));
+
+    // Update tracking
+    self.incremental_snapshot_count = 0;
+    self.last_full_snapshot_version = self.snapshot_version;
+    self.last_snapshot_crdt_version = self.crdt.get_clock().current_time();
+
+    Ok(snapshot_path)
+  }
+
+  /// Creates an incremental snapshot using MessagePack format.
+  #[cfg(feature = "msgpack")]
+  fn create_incremental_snapshot_msgpack(&mut self) -> Result<PathBuf, PersistError> {
+    use std::io::Write;
+
+    // Get changes since last snapshot
+    let (changed_records, new_tombstones) =
+      self.crdt.get_changed_since(self.last_snapshot_crdt_version);
+
+    // Skip creating snapshot if no changes (configurable)
+    // Empty snapshots provide no value since WAL contains all operations anyway.
+    // Only create empty snapshots if explicitly disabled via config (for testing).
+    //
+    // NOTE: When skipped, returns empty PathBuf and snapshot hooks are NOT called.
+    // This is intentional - backup systems shouldn't be notified of non-existent files.
+    // If your backup workflow requires periodic notifications even without changes,
+    // set skip_empty_incrementals = false (not recommended).
+    if self.config.skip_empty_incrementals
+      && changed_records.is_empty()
+      && new_tombstones.is_empty()
+    {
+      // Update last_snapshot_time to prevent repeated time-based triggers
+      // (prevents tight loop when no changes but snapshot_interval_secs is set)
+      self.last_snapshot_time = std::time::Instant::now();
+      return Ok(PathBuf::new()); // Return empty path to indicate skipped
+    }
+
+    // Increment snapshot version
+    self.snapshot_version += 1;
+
+    let metadata = SnapshotMetadata {
+      snapshot_type: SnapshotType::Incremental {
+        base_version: self.last_full_snapshot_version,
+      },
+      version: self.crdt.get_clock().current_time(),
+      format: SnapshotFormat::MessagePack,
+      created_at: std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or(std::time::Duration::from_secs(0))
+        .as_secs(),
+    };
+
+    let incremental_snapshot = IncrementalSnapshot {
+      metadata,
+      changed_records,
+      new_tombstones,
+      clock_version: self.crdt.get_clock().current_time(),
+    };
+
+    // Serialize to MessagePack
+    let bytes = rmp_serde::to_vec(&incremental_snapshot).map_err(|e| {
+      eprintln!(
+        "Failed to serialize incremental snapshot: {} records, {} tombstones",
+        incremental_snapshot.changed_records.len(),
+        incremental_snapshot.new_tombstones.len()
+      );
+      eprintln!("Serialization error: {}", e);
+      PersistError::MsgpackEncode(e)
+    })?;
+    let compressed = self.maybe_compress(bytes)?;
+
+    // Write to file
+    let snapshot_path = self.base_dir.join(format!(
+      "snapshot_incr_{:06}_base_{:06}.msgpack",
+      self.snapshot_version, self.last_full_snapshot_version
+    ));
+
+    {
+      let mut file = std::fs::File::create(&snapshot_path)?;
+      file.write_all(&compressed)?;
+      file.sync_all()?;
+      drop(file);
+    }
+
+    #[cfg(target_os = "windows")]
+    std::thread::sleep(std::time::Duration::from_millis(10));
+
+    // Update tracking
+    self.incremental_snapshot_count += 1;
+    self.last_snapshot_crdt_version = self.crdt.get_clock().current_time();
+
+    Ok(snapshot_path)
+  }
+
+  /// Creates a snapshot of the current CRDT state and rotates the WAL.
+  fn create_snapshot(&mut self) -> Result<(), PersistError> {
+    use std::io::Write;
+
+    let snapshot_path = match self.config.snapshot_format {
+      SnapshotFormat::Bincode => {
+        // Legacy bincode format (no incrementals)
+        let bytes = self.crdt.to_bytes().map_err(PersistError::BincodeEncode)?;
+
+        self.snapshot_version += 1;
+        let path = self
+          .base_dir
+          .join(format!("snapshot_{:06}.bin", self.snapshot_version));
+
+        {
+          let mut file = std::fs::File::create(&path)?;
+          file.write_all(&bytes)?;
+          file.sync_all()?;
+          drop(file);
+        }
+
+        #[cfg(target_os = "windows")]
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        path
+      }
+      #[cfg(feature = "msgpack")]
+      SnapshotFormat::MessagePack => {
+        if self.should_create_full_snapshot() {
+          self.create_full_snapshot_msgpack()?
+        } else {
+          self.create_incremental_snapshot_msgpack()?
+        }
+      }
+      #[cfg(not(feature = "msgpack"))]
+      SnapshotFormat::MessagePack => {
+        return Err(PersistError::UnsupportedFeature(
+          "MessagePack format requires 'msgpack' feature".to_string(),
+        ));
+      }
+    };
+
+    // Call snapshot hooks (file is now sealed and immutable)
+    // Skip calling hooks if snapshot was skipped (empty path)
+    if !snapshot_path.as_os_str().is_empty() {
+      let db_version = self.crdt.get_clock().current_time();
+      for hook in &self.snapshot_hooks {
+        hook.on_snapshot(&snapshot_path, db_version);
+      }
+    }
+
+    // Rotate WAL (seals old segments, calls hooks, starts new segment)
+    let _ = self.wal.rotate(&self.base_dir, &self.wal_segment_hooks)?;
+
+    // Auto-cleanup old snapshots if configured
+    if let Some(keep_count) = self.config.auto_cleanup_snapshots {
+      let _ = self.cleanup_old_snapshots(keep_count, false);
+    }
+
+    // Reset counter and timer
+    self.changes_since_snapshot = 0;
+    self.last_snapshot_time = Instant::now();
+
+    Ok(())
+  }
+
+  /// Checks if automatic snapshot threshold is reached and creates snapshot if needed.
+  /// Snapshots are triggered by either:
+  /// - Change count reaching snapshot_threshold (default: 1000)
+  /// - Time elapsed reaching snapshot_interval_secs (default: 300 = 5 minutes)
+  fn check_auto_snapshot(&mut self) -> Result<(), PersistError> {
+    let should_snapshot =
             // Change count threshold
             self.changes_since_snapshot >= self.config.snapshot_threshold ||
             // Time-based threshold
@@ -1413,230 +1427,243 @@ where
                 .map(|interval| self.last_snapshot_time.elapsed().as_secs() >= interval)
                 .unwrap_or(false);
 
-        if should_snapshot {
-            self.create_snapshot()?;
-        }
-        Ok(())
+    if should_snapshot {
+      self.create_snapshot()?;
+    }
+    Ok(())
+  }
+
+  /// Appends changes to the WAL and calls post-operation hooks.
+  fn persist_and_notify(&mut self, changes: &[Change<K, C, V>]) -> Result<(), PersistError> {
+    // Append to WAL (no fsync, OS buffers)
+    self.wal.append(changes)?;
+
+    // Update counter
+    self.changes_since_snapshot += changes.len();
+
+    // Add to batch collector
+    self.batch.extend_from_slice(changes);
+
+    // Check if batch size limit exceeded and auto-flush if needed
+    if let Some(max_size) = self.config.max_batch_size {
+      if self.batch.len() >= max_size {
+        // Auto-flush: clear the batch to prevent OOM
+        // Applications should call take_batch() before this happens
+        self.batch.clear();
+      }
     }
 
-    /// Appends changes to the WAL and calls post-operation hooks.
-    fn persist_and_notify(&mut self, changes: &[Change<K, C, V>]) -> Result<(), PersistError> {
-        // Append to WAL (no fsync, OS buffers)
-        self.wal.append(changes)?;
-
-        // Update counter
-        self.changes_since_snapshot += changes.len();
-
-        // Add to batch collector
-        self.batch.extend_from_slice(changes);
-
-        // Check if batch size limit exceeded and auto-flush if needed
-        if let Some(max_size) = self.config.max_batch_size {
-            if self.batch.len() >= max_size {
-                // Auto-flush: clear the batch to prevent OOM
-                // Applications should call take_batch() before this happens
-                self.batch.clear();
-            }
-        }
-
-        // Call post-hooks
-        for hook in &self.post_hooks {
-            hook.after_op(changes);
-        }
-
-        // Check if we need to snapshot
-        self.check_auto_snapshot()?;
-
-        Ok(())
+    // Call post-hooks
+    for hook in &self.post_hooks {
+      hook.after_op(changes);
     }
+
+    // Check if we need to snapshot
+    self.check_auto_snapshot()?;
+
+    Ok(())
+  }
 }
 
 // Public CRDT operation methods that integrate persistence
 impl<K, C, V> PersistedCRDT<K, C, V>
 where
-    K: Ord + Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
-    C: Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
-    V: Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+  K: Ord + Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+  C: Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+  V: Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
 {
-    /// Inserts or updates fields in a record.
-    ///
-    /// This operation:
-    /// 1. Applies changes to the in-memory CRDT
-    /// 2. Appends changes to the WAL
-    /// 3. Calls post-operation hooks
-    /// 4. Returns changes for network broadcast
-    /// 5. Auto-snapshots if threshold is reached
-    ///
-    /// # Arguments
-    ///
-    /// * `record_id` - The record to modify
-    /// * `fields` - Iterator of (column, value) pairs to insert/update
-    ///
-    /// # Returns
-    ///
-    /// Vector of changes that should be broadcast to network peers.
-    pub fn insert_or_update<I>(&mut self, record_id: &K, fields: I) -> Result<Vec<Change<K, C, V>>, PersistError>
-    where
-        I: IntoIterator<Item = (C, V)>,
-    {
-        // Apply to CRDT
-        let changes = self.crdt.insert_or_update(record_id, fields);
+  /// Inserts or updates fields in a record.
+  ///
+  /// This operation:
+  /// 1. Applies changes to the in-memory CRDT
+  /// 2. Appends changes to the WAL
+  /// 3. Calls post-operation hooks
+  /// 4. Returns changes for network broadcast
+  /// 5. Auto-snapshots if threshold is reached
+  ///
+  /// # Arguments
+  ///
+  /// * `record_id` - The record to modify
+  /// * `fields` - Iterator of (column, value) pairs to insert/update
+  ///
+  /// # Returns
+  ///
+  /// Vector of changes that should be broadcast to network peers.
+  pub fn insert_or_update<I>(
+    &mut self,
+    record_id: &K,
+    fields: I,
+  ) -> Result<Vec<Change<K, C, V>>, PersistError>
+  where
+    I: IntoIterator<Item = (C, V)>,
+  {
+    // Apply to CRDT
+    let changes = self.crdt.insert_or_update(record_id, fields);
 
-        // Persist and notify
-        self.persist_and_notify(&changes)?;
+    // Persist and notify
+    self.persist_and_notify(&changes)?;
 
-        Ok(changes)
+    Ok(changes)
+  }
+
+  /// Deletes an entire record (creates tombstone).
+  ///
+  /// See `insert_or_update` for operation flow.
+  pub fn delete_record(&mut self, record_id: &K) -> Result<Option<Change<K, C, V>>, PersistError> {
+    // Apply to CRDT
+    let change = self.crdt.delete_record(record_id);
+
+    if let Some(ref c) = change {
+      // Persist and notify
+      self.persist_and_notify(std::slice::from_ref(c))?;
     }
 
-    /// Deletes an entire record (creates tombstone).
-    ///
-    /// See `insert_or_update` for operation flow.
-    pub fn delete_record(&mut self, record_id: &K) -> Result<Option<Change<K, C, V>>, PersistError> {
-        // Apply to CRDT
-        let change = self.crdt.delete_record(record_id);
+    Ok(change)
+  }
 
-        if let Some(ref c) = change {
-            // Persist and notify
-            self.persist_and_notify(std::slice::from_ref(c))?;
-        }
+  /// Deletes a specific field from a record.
+  ///
+  /// See `insert_or_update` for operation flow.
+  pub fn delete_field(
+    &mut self,
+    record_id: &K,
+    field_name: &C,
+  ) -> Result<Option<Change<K, C, V>>, PersistError> {
+    // Apply to CRDT
+    let change = self.crdt.delete_field(record_id, field_name);
 
-        Ok(change)
+    if let Some(ref c) = change {
+      // Persist and notify
+      self.persist_and_notify(std::slice::from_ref(c))?;
     }
 
-    /// Deletes a specific field from a record.
-    ///
-    /// See `insert_or_update` for operation flow.
-    pub fn delete_field(&mut self, record_id: &K, field_name: &C) -> Result<Option<Change<K, C, V>>, PersistError> {
-        // Apply to CRDT
-        let change = self.crdt.delete_field(record_id, field_name);
+    Ok(change)
+  }
 
-        if let Some(ref c) = change {
-            // Persist and notify
-            self.persist_and_notify(std::slice::from_ref(c))?;
-        }
+  /// Merges incoming changes from remote nodes.
+  ///
+  /// This operation:
+  /// 1. Applies changes to the in-memory CRDT
+  /// 2. Appends accepted changes to the WAL
+  /// 3. Calls post-operation hooks
+  /// 4. Returns accepted changes
+  /// 5. Auto-snapshots if threshold is reached
+  ///
+  /// # Arguments
+  ///
+  /// * `changes` - Changes received from remote nodes
+  ///
+  /// # Returns
+  ///
+  /// Vector of changes that were accepted (won conflict resolution).
+  pub fn merge_changes(
+    &mut self,
+    changes: Vec<Change<K, C, V>>,
+  ) -> Result<Vec<Change<K, C, V>>, PersistError> {
+    // Apply to CRDT with default merge rule
+    let accepted = self.crdt.merge_changes(changes, &DefaultMergeRule);
 
-        Ok(change)
-    }
+    // Persist and notify (only accepted changes)
+    self.persist_and_notify(&accepted)?;
 
-    /// Merges incoming changes from remote nodes.
-    ///
-    /// This operation:
-    /// 1. Applies changes to the in-memory CRDT
-    /// 2. Appends accepted changes to the WAL
-    /// 3. Calls post-operation hooks
-    /// 4. Returns accepted changes
-    /// 5. Auto-snapshots if threshold is reached
-    ///
-    /// # Arguments
-    ///
-    /// * `changes` - Changes received from remote nodes
-    ///
-    /// # Returns
-    ///
-    /// Vector of changes that were accepted (won conflict resolution).
-    pub fn merge_changes(&mut self, changes: Vec<Change<K, C, V>>) -> Result<Vec<Change<K, C, V>>, PersistError> {
-        // Apply to CRDT with default merge rule
-        let accepted = self.crdt.merge_changes(changes, &DefaultMergeRule);
+    Ok(accepted)
+  }
 
-        // Persist and notify (only accepted changes)
-        self.persist_and_notify(&accepted)?;
+  /// Merges incoming changes with a custom merge rule.
+  pub fn merge_changes_with_rule<R: MergeRule<K, C, V>>(
+    &mut self,
+    changes: Vec<Change<K, C, V>>,
+    merge_rule: &R,
+  ) -> Result<Vec<Change<K, C, V>>, PersistError> {
+    // Apply to CRDT with custom merge rule
+    let accepted = self.crdt.merge_changes(changes, merge_rule);
 
-        Ok(accepted)
-    }
+    // Persist and notify
+    self.persist_and_notify(&accepted)?;
 
-    /// Merges incoming changes with a custom merge rule.
-    pub fn merge_changes_with_rule<R: MergeRule<K, C, V>>(
-        &mut self,
-        changes: Vec<Change<K, C, V>>,
-        merge_rule: &R,
-    ) -> Result<Vec<Change<K, C, V>>, PersistError> {
-        // Apply to CRDT with custom merge rule
-        let accepted = self.crdt.merge_changes(changes, merge_rule);
+    Ok(accepted)
+  }
 
-        // Persist and notify
-        self.persist_and_notify(&accepted)?;
+  /// Gets changes since a specific version, excluding certain nodes.
+  ///
+  /// Useful for syncing with remote peers.
+  pub fn get_changes_since_excluding(
+    &self,
+    last_db_version: u64,
+    excluding: &HashSet<NodeId>,
+  ) -> Vec<Change<K, C, V>>
+  where
+    K: Ord,
+    C: Ord,
+  {
+    self
+      .crdt
+      .get_changes_since_excluding(last_db_version, excluding)
+  }
 
-        Ok(accepted)
-    }
+  /// Gets all changes since a specific version.
+  pub fn get_changes_since(&self, last_db_version: u64) -> Vec<Change<K, C, V>>
+  where
+    K: Ord,
+    C: Ord,
+  {
+    self.crdt.get_changes_since(last_db_version)
+  }
 
-    /// Gets changes since a specific version, excluding certain nodes.
-    ///
-    /// Useful for syncing with remote peers.
-    pub fn get_changes_since_excluding(
-        &self,
-        last_db_version: u64,
-        excluding: &HashSet<NodeId>,
-    ) -> Vec<Change<K, C, V>>
-    where
-        K: Ord,
-        C: Ord,
-    {
-        self.crdt.get_changes_since_excluding(last_db_version, excluding)
-    }
+  /// Compacts tombstones that have been acknowledged by all nodes.
+  ///
+  /// This method performs atomic tombstone compaction with automatic WAL cleanup
+  /// to prevent zombie records. It performs:
+  /// 1. Tombstone compaction in memory
+  /// 2. Snapshot creation with compacted state
+  /// 3. Deletion of old WAL segments (which contain tombstone records)
+  ///
+  /// **IMPORTANT**: Only call this after verifying all nodes have acknowledged
+  /// the `min_acknowledged_version`. Otherwise, deleted records may reappear.
+  ///
+  /// # Arguments
+  ///
+  /// * `min_acknowledged_version` - The minimum db_version acknowledged by all nodes
+  ///
+  /// # Returns
+  ///
+  /// `Ok(())` on success, or `PersistError` if snapshot creation or cleanup fails.
+  ///
+  /// # Example
+  ///
+  /// ```no_run
+  /// # use crdt_lite::persist::{PersistedCRDT, PersistConfig};
+  /// # use std::path::PathBuf;
+  /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+  /// # let mut pcrdt = PersistedCRDT::<String, String, String>::open(
+  /// #     PathBuf::from("./data"), 1, PersistConfig::default())?;
+  /// // After confirming all nodes have acknowledged version 1000
+  /// pcrdt.compact_tombstones(1000)?;
+  /// # Ok(())
+  /// # }
+  /// ```
+  pub fn compact_tombstones(&mut self, min_acknowledged_version: u64) -> Result<(), PersistError> {
+    // Compact tombstones in memory
+    self.crdt.compact_tombstones(min_acknowledged_version);
 
-    /// Gets all changes since a specific version.
-    pub fn get_changes_since(&self, last_db_version: u64) -> Vec<Change<K, C, V>>
-    where
-        K: Ord,
-        C: Ord,
-    {
-        self.crdt.get_changes_since(last_db_version)
-    }
+    // Force snapshot after compaction to persist the cleaned state
+    self.create_snapshot()?;
 
-    /// Compacts tombstones that have been acknowledged by all nodes.
-    ///
-    /// This method performs atomic tombstone compaction with automatic WAL cleanup
-    /// to prevent zombie records. It performs:
-    /// 1. Tombstone compaction in memory
-    /// 2. Snapshot creation with compacted state
-    /// 3. Deletion of old WAL segments (which contain tombstone records)
-    ///
-    /// **IMPORTANT**: Only call this after verifying all nodes have acknowledged
-    /// the `min_acknowledged_version`. Otherwise, deleted records may reappear.
-    ///
-    /// # Arguments
-    ///
-    /// * `min_acknowledged_version` - The minimum db_version acknowledged by all nodes
-    ///
-    /// # Returns
-    ///
-    /// `Ok(())` on success, or `PersistError` if snapshot creation or cleanup fails.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// # use crdt_lite::persist::{PersistedCRDT, PersistConfig};
-    /// # use std::path::PathBuf;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let mut pcrdt = PersistedCRDT::<String, String, String>::open(
-    /// #     PathBuf::from("./data"), 1, PersistConfig::default())?;
-    /// // After confirming all nodes have acknowledged version 1000
-    /// pcrdt.compact_tombstones(1000)?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn compact_tombstones(&mut self, min_acknowledged_version: u64) -> Result<(), PersistError> {
-        // Compact tombstones in memory
-        self.crdt.compact_tombstones(min_acknowledged_version);
+    // CRITICAL: Delete old WAL segments that contain tombstone records
+    // Failure to do this causes zombie records to reappear on recovery
+    // Use require_uploaded=false to unconditionally delete all old segments
+    self.cleanup_old_wal_segments(0, false)?;
 
-        // Force snapshot after compaction to persist the cleaned state
-        self.create_snapshot()?;
+    Ok(())
+  }
 
-        // CRITICAL: Delete old WAL segments that contain tombstone records
-        // Failure to do this causes zombie records to reappear on recovery
-        // Use require_uploaded=false to unconditionally delete all old segments
-        self.cleanup_old_wal_segments(0, false)?;
+  /// Returns the current logical clock value.
+  pub fn get_clock_time(&self) -> u64 {
+    self.crdt.get_clock().current_time()
+  }
 
-        Ok(())
-    }
-
-    /// Returns the current logical clock value.
-    pub fn get_clock_time(&self) -> u64 {
-        self.crdt.get_clock().current_time()
-    }
-
-    /// Returns the node ID of this CRDT instance.
-    pub fn node_id(&self) -> NodeId {
-        self.crdt.node_id
-    }
+  /// Returns the node ID of this CRDT instance.
+  pub fn node_id(&self) -> NodeId {
+    self.crdt.node_id
+  }
 }

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -253,9 +253,14 @@ pub struct PersistConfig {
   pub enable_compression: bool,
   /// Skip creating incremental snapshots when there are no changes
   pub skip_empty_incrementals: bool,
-  /// Auto-cleanup old WAL segments after snapshot (default: true)
-  /// Set to false if you have async upload hooks and need to track uploads manually.
-  /// When false, you must call `cleanup_old_wal_segments()` manually after uploads complete.
+  /// Auto-cleanup old WAL segments after snapshot.
+  ///
+  /// Used by `StreamingCRDT` only (`PersistedCRDT` does not auto-delete WAL segments).
+  ///
+  /// - `Some(true)`: Always auto-cleanup after snapshot
+  /// - `Some(false)`: Never auto-cleanup (use `cleanup_old_wal_segments()` manually)
+  /// - `None` (default): Auto-cleanup unless WAL segment hooks are registered
+  ///   (prevents deleting files before async upload hooks complete)
   pub auto_cleanup_wal: Option<bool>,
 }
 
@@ -282,7 +287,7 @@ impl Default for PersistConfig {
       full_snapshot_interval: DEFAULT_FULL_SNAPSHOT_INTERVAL,
       enable_compression: false,
       skip_empty_incrementals: true,
-      auto_cleanup_wal: Some(true), // Default: auto-cleanup WAL after snapshots
+      auto_cleanup_wal: None, // Default: auto-cleanup unless WAL segment hooks registered
     }
   }
 }

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -253,6 +253,10 @@ pub struct PersistConfig {
   pub enable_compression: bool,
   /// Skip creating incremental snapshots when there are no changes
   pub skip_empty_incrementals: bool,
+  /// Auto-cleanup old WAL segments after snapshot (default: true)
+  /// Set to false if you have async upload hooks and need to track uploads manually.
+  /// When false, you must call `cleanup_old_wal_segments()` manually after uploads complete.
+  pub auto_cleanup_wal: Option<bool>,
 }
 
 impl Default for PersistConfig {
@@ -278,6 +282,7 @@ impl Default for PersistConfig {
       full_snapshot_interval: DEFAULT_FULL_SNAPSHOT_INTERVAL,
       enable_compression: false,
       skip_empty_incrementals: true,
+      auto_cleanup_wal: Some(true), // Default: auto-cleanup WAL after snapshots
     }
   }
 }

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -101,9 +101,11 @@
 //! ```
 
 mod hooks;
+pub mod streaming;
 mod wal;
 
 pub use hooks::{PostOpHook, SnapshotHook, WalSegmentHook};
+pub use streaming::{StreamingCRDT, StreamingConfig};
 
 use crate::{Change, DefaultMergeRule, MergeRule, NodeId, Record, TombstoneInfo, CRDT};
 use std::collections::HashMap;

--- a/src/persist/hooks.rs
+++ b/src/persist/hooks.rs
@@ -59,18 +59,18 @@ use std::path::Path;
 /// ```
 pub trait PostOpHook<K, C, V>: Send + Sync
 where
-    K: Hash + Eq + Clone,
-    C: Hash + Eq + Clone,
-    V: Clone,
+  K: Hash + Eq + Clone,
+  C: Hash + Eq + Clone,
+  V: Clone,
 {
-    /// Called after changes have been applied and written (but not fsynced).
-    ///
-    /// This fires immediately after WAL write to minimize broadcast latency.
-    /// Local fsync is deferred to snapshot time for CRDT performance.
-    ///
-    /// This should be fast and non-blocking. For network I/O, send changes
-    /// to an async task rather than blocking here.
-    fn after_op(&self, changes: &[Change<K, C, V>]);
+  /// Called after changes have been applied and written (but not fsynced).
+  ///
+  /// This fires immediately after WAL write to minimize broadcast latency.
+  /// Local fsync is deferred to snapshot time for CRDT performance.
+  ///
+  /// This should be fast and non-blocking. For network I/O, send changes
+  /// to an async task rather than blocking here.
+  fn after_op(&self, changes: &[Change<K, C, V>]);
 }
 
 /// Snapshot hook for backup and replication.
@@ -108,16 +108,16 @@ where
 /// }
 /// ```
 pub trait SnapshotHook: Send + Sync {
-    /// Called after a snapshot has been created and sealed.
-    ///
-    /// The snapshot file is immutable and safe for async upload.
-    /// This is called synchronously but should spawn async tasks for I/O.
-    ///
-    /// # Arguments
-    ///
-    /// * `snapshot_path` - Path to the sealed snapshot file
-    /// * `db_version` - The CRDT version (logical clock) at time of snapshot
-    fn on_snapshot(&self, snapshot_path: &Path, db_version: u64);
+  /// Called after a snapshot has been created and sealed.
+  ///
+  /// The snapshot file is immutable and safe for async upload.
+  /// This is called synchronously but should spawn async tasks for I/O.
+  ///
+  /// # Arguments
+  ///
+  /// * `snapshot_path` - Path to the sealed snapshot file
+  /// * `db_version` - The CRDT version (logical clock) at time of snapshot
+  fn on_snapshot(&self, snapshot_path: &Path, db_version: u64);
 }
 
 /// WAL segment hook for archival.
@@ -152,70 +152,70 @@ pub trait SnapshotHook: Send + Sync {
 /// }
 /// ```
 pub trait WalSegmentHook: Send + Sync {
-    /// Called after a WAL segment has been sealed (no longer active).
-    ///
-    /// The segment file is immutable and safe for async upload.
-    fn on_wal_sealed(&self, segment_path: &Path);
+  /// Called after a WAL segment has been sealed (no longer active).
+  ///
+  /// The segment file is immutable and safe for async upload.
+  fn on_wal_sealed(&self, segment_path: &Path);
 }
 
 // Convenience implementations for closures
 
 impl<K, C, V, F> PostOpHook<K, C, V> for F
 where
-    K: Hash + Eq + Clone,
-    C: Hash + Eq + Clone,
-    V: Clone,
-    F: Fn(&[Change<K, C, V>]) + Send + Sync,
+  K: Hash + Eq + Clone,
+  C: Hash + Eq + Clone,
+  V: Clone,
+  F: Fn(&[Change<K, C, V>]) + Send + Sync,
 {
-    fn after_op(&self, changes: &[Change<K, C, V>]) {
-        self(changes)
-    }
+  fn after_op(&self, changes: &[Change<K, C, V>]) {
+    self(changes)
+  }
 }
 
 impl<F> SnapshotHook for F
 where
-    F: Fn(&Path, u64) + Send + Sync,
+  F: Fn(&Path, u64) + Send + Sync,
 {
-    fn on_snapshot(&self, snapshot_path: &Path, db_version: u64) {
-        self(snapshot_path, db_version)
-    }
+  fn on_snapshot(&self, snapshot_path: &Path, db_version: u64) {
+    self(snapshot_path, db_version)
+  }
 }
 
 impl<F> WalSegmentHook for F
 where
-    F: Fn(&Path) + Send + Sync,
+  F: Fn(&Path) + Send + Sync,
 {
-    fn on_wal_sealed(&self, segment_path: &Path) {
-        self(segment_path)
-    }
+  fn on_wal_sealed(&self, segment_path: &Path) {
+    self(segment_path)
+  }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+  use super::*;
 
-    #[test]
-    fn test_hook_closure() {
-        let counter = std::sync::Arc::new(std::sync::Mutex::new(0));
-        let counter_clone = counter.clone();
+  #[test]
+  fn test_hook_closure() {
+    let counter = std::sync::Arc::new(std::sync::Mutex::new(0));
+    let counter_clone = counter.clone();
 
-        let hook = move |changes: &[Change<String, String, String>]| {
-            *counter_clone.lock().unwrap() += changes.len();
-        };
+    let hook = move |changes: &[Change<String, String, String>]| {
+      *counter_clone.lock().unwrap() += changes.len();
+    };
 
-        let changes = vec![Change {
-            record_id: "rec1".to_string(),
-            col_name: Some("field1".to_string()),
-            value: Some("value1".to_string()),
-            col_version: 1,
-            db_version: 1,
-            node_id: 1,
-            local_db_version: 1,
-            flags: 0,
-        }];
+    let changes = vec![Change {
+      record_id: "rec1".to_string(),
+      col_name: Some("field1".to_string()),
+      value: Some("value1".to_string()),
+      col_version: 1,
+      db_version: 1,
+      node_id: 1,
+      local_db_version: 1,
+      flags: 0,
+    }];
 
-        hook.after_op(&changes);
+    hook.after_op(&changes);
 
-        assert_eq!(*counter.lock().unwrap(), 1);
-    }
+    assert_eq!(*counter.lock().unwrap(), 1);
+  }
 }

--- a/src/persist/streaming.rs
+++ b/src/persist/streaming.rs
@@ -740,11 +740,11 @@ where
           record_id: key,
           col_name: None,
           value: None,
-          col_version: 0,
+          col_version: u64::MAX, // TOMBSTONE_COL_VERSION
           db_version: tombstone.db_version,
           node_id: tombstone.node_id,
           local_db_version: tombstone.local_db_version,
-          flags: 1,
+          flags: 0,
         });
       }
 
@@ -800,6 +800,16 @@ where
 
       let offset = file.stream_position()?;
       let record_bytes = rmp_serde::to_vec(record).map_err(PersistError::MsgpackEncode)?;
+
+      // Validate record size fits in u32 (index uses u32 for length)
+      if record_bytes.len() > u32::MAX as usize {
+        return Err(PersistError::InvalidDirectory(format!(
+          "Record too large: {} bytes (max {} bytes)",
+          record_bytes.len(),
+          u32::MAX
+        )));
+      }
+
       file.write_all(&record_bytes)?;
 
       index_entries.push(IndexEntry {
@@ -944,9 +954,26 @@ where
     let mut tombstone_map: HashMap<K, TombstoneInfo> = HashMap::new();
 
     // Add cold tombstones not superseded by hot
+    // A cold tombstone should be included unless the hot tier has explicitly
+    // handled this key (either as a live record or as its own tombstone).
+    // Checking hot_keys alone is insufficient: if a key is in hot_keys but
+    // has no live record and no hot tombstone, the cold tombstone would be
+    // lost, causing zombie record resurrection on next recovery.
     for (key, info) in self.cold.tombstones.iter() {
-      if !self.hot_keys.contains(key) {
-        tombstone_map.insert(key.clone(), *info);
+      if !self.hot_keys.contains(key) || !self.hot_tombstones.contains(key) {
+        // If key is not in hot at all, preserve cold tombstone.
+        // If key is in hot_keys but also in hot_tombstones, the hot tombstone
+        // will be added below (and may supersede this one via HashMap insert).
+        if !self.hot_keys.contains(key) {
+          tombstone_map.insert(key.clone(), *info);
+        } else if !self.hot_tombstones.contains(key) {
+          // Key is in hot_keys but has no hot tombstone and no hot record —
+          // this is an inconsistent state. Preserve the cold tombstone to
+          // prevent zombie records.
+          if self.hot.get_record(key).is_none() {
+            tombstone_map.insert(key.clone(), *info);
+          }
+        }
       }
     }
 
@@ -1040,10 +1067,9 @@ where
       if let Some(record) = self.hot.get_record(key) {
         return Ok(Some(record.clone()));
       }
-      // Key is in hot but record was deleted
-      if self.hot_tombstones.contains(key) {
-        return Ok(None);
-      }
+      // Key is tracked in hot but has no live record — either it's tombstoned
+      // or in an inconsistent state. Either way, don't fall through to cold.
+      return Ok(None);
     }
 
     // 2. Check if tombstoned (hot or cold)

--- a/src/persist/streaming.rs
+++ b/src/persist/streaming.rs
@@ -71,10 +71,7 @@
 //! # }
 //! ```
 
-use crate::{
-    Change, DefaultMergeRule, NodeId, Record,
-    TombstoneInfo, TombstoneStorage, CRDT,
-};
+use crate::{Change, DefaultMergeRule, NodeId, Record, TombstoneInfo, TombstoneStorage, CRDT};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs::File;
 use std::hash::Hash;
@@ -102,328 +99,332 @@ type MigrationResult<K, C, V> = Result<Option<(ColdStorage<K, C, V>, u64, u64)>,
 /// Configuration for streaming CRDT
 #[derive(Debug, Clone)]
 pub struct StreamingConfig {
-    /// Maximum number of cold records to keep in LRU cache
-    pub cache_capacity: usize,
-    /// Underlying persistence config (for WAL, snapshots, etc.)
-    pub persist_config: PersistConfig,
+  /// Maximum number of cold records to keep in LRU cache
+  pub cache_capacity: usize,
+  /// Underlying persistence config (for WAL, snapshots, etc.)
+  pub persist_config: PersistConfig,
 }
 
 impl Default for StreamingConfig {
-    fn default() -> Self {
-        Self {
-            cache_capacity: DEFAULT_CACHE_CAPACITY,
-            persist_config: PersistConfig::default(),
-        }
+  fn default() -> Self {
+    Self {
+      cache_capacity: DEFAULT_CACHE_CAPACITY,
+      persist_config: PersistConfig::default(),
     }
+  }
 }
 
 /// Entry in the snapshot index
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct IndexEntry<K> {
-    key: K,
-    offset: u64,
-    length: u32,
-    /// Highest local_db_version in this record (for efficient sync queries)
-    #[cfg_attr(feature = "serde", serde(default))]
-    highest_version: u64,
+  key: K,
+  offset: u64,
+  length: u32,
+  /// Highest local_db_version in this record (for efficient sync queries)
+  #[cfg_attr(feature = "serde", serde(default))]
+  highest_version: u64,
 }
 
 /// O(1) LRU cache implementation using HashMap + VecDeque with reference counting
 struct LruCache<K, V> {
-    capacity: usize,
-    map: HashMap<K, V>,
-    /// Keys in order of access (oldest at front, newest at back)
-    order: VecDeque<K>,
-    /// Count how many times each key appears in the order queue
-    /// Only evict when count reaches 0
-    ref_count: HashMap<K, usize>,
+  capacity: usize,
+  map: HashMap<K, V>,
+  /// Keys in order of access (oldest at front, newest at back)
+  order: VecDeque<K>,
+  /// Count how many times each key appears in the order queue
+  /// Only evict when count reaches 0
+  ref_count: HashMap<K, usize>,
 }
 
 impl<K: Hash + Eq + Clone, V> LruCache<K, V> {
-    fn new(capacity: usize) -> Self {
-        Self {
-            capacity: capacity.max(1), // Ensure at least 1
-            map: HashMap::with_capacity(capacity),
-            order: VecDeque::with_capacity(capacity * 2),
-            ref_count: HashMap::with_capacity(capacity),
+  fn new(capacity: usize) -> Self {
+    Self {
+      capacity: capacity.max(1), // Ensure at least 1
+      map: HashMap::with_capacity(capacity),
+      order: VecDeque::with_capacity(capacity * 2),
+      ref_count: HashMap::with_capacity(capacity),
+    }
+  }
+
+  fn get(&mut self, key: &K) -> Option<&V> {
+    if self.map.contains_key(key) {
+      // Mark as recently used by adding to back
+      self.order.push_back(key.clone());
+      *self.ref_count.entry(key.clone()).or_insert(0) += 1;
+      self.map.get(key)
+    } else {
+      None
+    }
+  }
+
+  fn insert(&mut self, key: K, value: V) {
+    let is_new = !self.map.contains_key(&key);
+    if is_new {
+      // Evict if at capacity
+      while self.map.len() >= self.capacity {
+        self.evict_one();
+      }
+      // Only update order for new keys
+      self.order.push_back(key.clone());
+      *self.ref_count.entry(key.clone()).or_insert(0) += 1;
+    }
+    // Always update the value
+    self.map.insert(key, value);
+
+    // Compact order queue if it gets too large (prevents unbounded growth)
+    if self.order.len() > self.capacity * 3 {
+      self.compact();
+    }
+  }
+
+  /// Rebuild order queue to remove stale entries
+  fn compact(&mut self) {
+    let mut new_order = VecDeque::with_capacity(self.capacity * 2);
+    let mut new_ref_count: HashMap<K, usize> = HashMap::with_capacity(self.capacity);
+
+    // Keep only the most recent entry for each key
+    for key in self.order.drain(..).rev() {
+      if self.map.contains_key(&key) && !new_ref_count.contains_key(&key) {
+        new_ref_count.insert(key.clone(), 1);
+        new_order.push_front(key);
+      }
+    }
+
+    self.order = new_order;
+    self.ref_count = new_ref_count;
+  }
+
+  fn evict_one(&mut self) {
+    // Pop from front until we find a key with ref_count == 1 (last reference)
+    while let Some(oldest) = self.order.pop_front() {
+      let count = self.ref_count.get_mut(&oldest);
+      match count {
+        Some(c) if *c > 1 => {
+          // Key has newer references, skip this stale one
+          *c -= 1;
         }
-    }
-
-    fn get(&mut self, key: &K) -> Option<&V> {
-        if self.map.contains_key(key) {
-            // Mark as recently used by adding to back
-            self.order.push_back(key.clone());
-            *self.ref_count.entry(key.clone()).or_insert(0) += 1;
-            self.map.get(key)
-        } else {
-            None
+        Some(_) => {
+          // Last reference, evict this key
+          self.ref_count.remove(&oldest);
+          self.map.remove(&oldest);
+          break;
         }
-    }
-
-    fn insert(&mut self, key: K, value: V) {
-        let is_new = !self.map.contains_key(&key);
-        if is_new {
-            // Evict if at capacity
-            while self.map.len() >= self.capacity {
-                self.evict_one();
-            }
-            // Only update order for new keys
-            self.order.push_back(key.clone());
-            *self.ref_count.entry(key.clone()).or_insert(0) += 1;
+        None => {
+          // Key not in map (already evicted), continue
         }
-        // Always update the value
-        self.map.insert(key, value);
-
-        // Compact order queue if it gets too large (prevents unbounded growth)
-        if self.order.len() > self.capacity * 3 {
-            self.compact();
-        }
+      }
     }
+  }
 
-    /// Rebuild order queue to remove stale entries
-    fn compact(&mut self) {
-        let mut new_order = VecDeque::with_capacity(self.capacity * 2);
-        let mut new_ref_count: HashMap<K, usize> = HashMap::with_capacity(self.capacity);
+  fn contains_key(&self, key: &K) -> bool {
+    self.map.contains_key(key)
+  }
 
-        // Keep only the most recent entry for each key
-        for key in self.order.drain(..).rev() {
-            if self.map.contains_key(&key) && !new_ref_count.contains_key(&key) {
-                new_ref_count.insert(key.clone(), 1);
-                new_order.push_front(key);
-            }
-        }
-
-        self.order = new_order;
-        self.ref_count = new_ref_count;
-    }
-
-    fn evict_one(&mut self) {
-        // Pop from front until we find a key with ref_count == 1 (last reference)
-        while let Some(oldest) = self.order.pop_front() {
-            let count = self.ref_count.get_mut(&oldest);
-            match count {
-                Some(c) if *c > 1 => {
-                    // Key has newer references, skip this stale one
-                    *c -= 1;
-                }
-                Some(_) => {
-                    // Last reference, evict this key
-                    self.ref_count.remove(&oldest);
-                    self.map.remove(&oldest);
-                    break;
-                }
-                None => {
-                    // Key not in map (already evicted), continue
-                }
-            }
-        }
-    }
-
-    fn contains_key(&self, key: &K) -> bool {
-        self.map.contains_key(key)
-    }
-
-    #[allow(dead_code)]
-    fn clear(&mut self) {
-        self.map.clear();
-        self.order.clear();
-        self.ref_count.clear();
-    }
+  #[allow(dead_code)]
+  fn clear(&mut self) {
+    self.map.clear();
+    self.order.clear();
+    self.ref_count.clear();
+  }
 }
 
 /// Cold storage backed by an indexed snapshot file
 struct ColdStorage<K, C, V>
 where
-    K: Ord + Hash + Eq + Clone,
-    C: Hash + Eq + Clone,
-    V: Clone,
+  K: Ord + Hash + Eq + Clone,
+  C: Hash + Eq + Clone,
+  V: Clone,
 {
-    /// The snapshot file (kept open for seeking)
-    file: Option<BufReader<File>>,
-    /// Key -> (offset, length, highest_local_db_version) index
-    /// The version is used for efficient get_changes_since queries
-    index: HashMap<K, (u64, u32, u64)>,
-    /// Tombstones (loaded entirely at startup)
-    tombstones: TombstoneStorage<K>,
-    /// Clock value from snapshot
-    clock_value: u64,
-    /// Phantom data for type parameters
-    _phantom: std::marker::PhantomData<(C, V)>,
+  /// Path to snapshot file (opened on-demand to avoid FD exhaustion)
+  snapshot_path: Option<PathBuf>,
+  /// Key -> (offset, length, highest_local_db_version) index
+  /// The version is used for efficient get_changes_since queries
+  index: HashMap<K, (u64, u32, u64)>,
+  /// Tombstones (loaded entirely at startup)
+  tombstones: TombstoneStorage<K>,
+  /// Clock value from snapshot
+  clock_value: u64,
+  /// Phantom data for type parameters
+  _phantom: std::marker::PhantomData<(C, V)>,
 }
 
 impl<K, C, V> ColdStorage<K, C, V>
 where
-    K: Ord + Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
-    C: Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
-    V: Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+  K: Ord + Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+  C: Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+  V: Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
 {
-    /// Create empty cold storage (no snapshot file)
-    fn empty() -> Self {
-        Self {
-            file: None,
-            index: HashMap::new(),
-            tombstones: TombstoneStorage::new(),
-            clock_value: 0,
-            _phantom: std::marker::PhantomData,
-        }
+  /// Create empty cold storage (no snapshot file)
+  fn empty() -> Self {
+    Self {
+      snapshot_path: None,
+      index: HashMap::new(),
+      tombstones: TombstoneStorage::new(),
+      clock_value: 0,
+      _phantom: std::marker::PhantomData,
+    }
+  }
+
+  /// Load cold storage from an indexed snapshot file
+  fn from_file(path: &PathBuf) -> Result<Self, PersistError> {
+    let file = File::open(path)?;
+    let file_len = file.metadata()?.len();
+    let mut reader = BufReader::new(file);
+
+    // Read and verify magic
+    let mut magic = [0u8; 4];
+    reader.read_exact(&mut magic)?;
+    if &magic != SNAPSHOT_MAGIC {
+      return Err(PersistError::InvalidDirectory(
+        "Invalid snapshot magic bytes".to_string(),
+      ));
     }
 
-    /// Load cold storage from an indexed snapshot file
-    fn from_file(path: &PathBuf) -> Result<Self, PersistError> {
-        let file = File::open(path)?;
-        let file_len = file.metadata()?.len();
-        let mut reader = BufReader::new(file);
+    // Read version and flags
+    let mut version_flags = [0u8; 2];
+    reader.read_exact(&mut version_flags)?;
+    let version = version_flags[0];
+    if version != SNAPSHOT_VERSION {
+      return Err(PersistError::InvalidDirectory(format!(
+        "Unsupported snapshot version: {}",
+        version
+      )));
+    }
+    // flags[1] reserved for future use
 
-        // Read and verify magic
-        let mut magic = [0u8; 4];
-        reader.read_exact(&mut magic)?;
-        if &magic != SNAPSHOT_MAGIC {
-            return Err(PersistError::InvalidDirectory(
-                "Invalid snapshot magic bytes".to_string(),
-            ));
-        }
+    // Read header fields
+    let mut header_buf = vec![0u8; HEADER_SIZE];
+    reader.read_exact(&mut header_buf)?;
 
-        // Read version and flags
-        let mut version_flags = [0u8; 2];
-        reader.read_exact(&mut version_flags)?;
-        let version = version_flags[0];
-        if version != SNAPSHOT_VERSION {
-            return Err(PersistError::InvalidDirectory(format!(
-                "Unsupported snapshot version: {}",
-                version
-            )));
-        }
-        // flags[1] reserved for future use
+    // Parse header - NodeId size varies based on feature flag
+    let node_id_size = std::mem::size_of::<NodeId>();
+    let mut offset = 0;
 
-        // Read header fields
-        let mut header_buf = vec![0u8; HEADER_SIZE];
-        reader.read_exact(&mut header_buf)?;
+    // Skip node_id (we don't need it for loading)
+    offset += node_id_size;
 
-        // Parse header - NodeId size varies based on feature flag
-        let node_id_size = std::mem::size_of::<NodeId>();
-        let mut offset = 0;
+    let clock_value = u64::from_le_bytes(header_buf[offset..offset + 8].try_into().unwrap());
+    offset += 8;
 
-        // Skip node_id (we don't need it for loading)
-        offset += node_id_size;
+    let record_count = u64::from_le_bytes(header_buf[offset..offset + 8].try_into().unwrap());
+    offset += 8;
 
-        let clock_value = u64::from_le_bytes(header_buf[offset..offset + 8].try_into().unwrap());
-        offset += 8;
+    let tombstone_count = u64::from_le_bytes(header_buf[offset..offset + 8].try_into().unwrap());
+    offset += 8;
 
-        let record_count = u64::from_le_bytes(header_buf[offset..offset + 8].try_into().unwrap());
-        offset += 8;
+    let index_offset = u64::from_le_bytes(header_buf[offset..offset + 8].try_into().unwrap());
+    offset += 8;
 
-        let tombstone_count = u64::from_le_bytes(header_buf[offset..offset + 8].try_into().unwrap());
-        offset += 8;
+    let tombstones_offset = u64::from_le_bytes(header_buf[offset..offset + 8].try_into().unwrap());
 
-        let index_offset = u64::from_le_bytes(header_buf[offset..offset + 8].try_into().unwrap());
-        offset += 8;
+    let _ = (record_count, tombstone_count); // Silence unused warnings
 
-        let tombstones_offset = u64::from_le_bytes(header_buf[offset..offset + 8].try_into().unwrap());
-
-        let _ = (record_count, tombstone_count); // Silence unused warnings
-
-        // Validate offsets
-        if index_offset == 0 || index_offset >= file_len {
-            return Err(PersistError::InvalidDirectory(format!(
-                "Invalid index_offset {} (file_len={})", index_offset, file_len
-            )));
-        }
-        if tombstones_offset == 0 || tombstones_offset >= file_len || tombstones_offset > index_offset {
-            return Err(PersistError::InvalidDirectory(format!(
-                "Invalid tombstones_offset {} (index_offset={}, file_len={})",
-                tombstones_offset, index_offset, file_len
-            )));
-        }
-
-        // Load index from end of file
-        reader.seek(SeekFrom::Start(index_offset))?;
-        let index_entries: Vec<IndexEntry<K>> = rmp_serde::from_read(&mut reader)
-            .map_err(PersistError::MsgpackDecode)?;
-
-        let index: HashMap<K, (u64, u32, u64)> = index_entries
-            .into_iter()
-            .map(|e| (e.key, (e.offset, e.length, e.highest_version)))
-            .collect();
-
-        // Load tombstones
-        reader.seek(SeekFrom::Start(tombstones_offset))?;
-        let tombstone_map: HashMap<K, TombstoneInfo> = rmp_serde::from_read(&mut reader)
-            .map_err(PersistError::MsgpackDecode)?;
-
-        let mut tombstones = TombstoneStorage::new();
-        for (key, info) in tombstone_map {
-            tombstones.insert_or_assign(key, info);
-        }
-
-        // Reuse the same reader - just seek when needed for record access
-        // No need to reopen the file (fixes file descriptor leak)
-
-        Ok(Self {
-            file: Some(reader),
-            index,
-            tombstones,
-            clock_value,
-            _phantom: std::marker::PhantomData,
-        })
+    // Validate offsets
+    if index_offset == 0 || index_offset >= file_len {
+      return Err(PersistError::InvalidDirectory(format!(
+        "Invalid index_offset {} (file_len={})",
+        index_offset, file_len
+      )));
+    }
+    if tombstones_offset == 0 || tombstones_offset >= file_len || tombstones_offset > index_offset {
+      return Err(PersistError::InvalidDirectory(format!(
+        "Invalid tombstones_offset {} (index_offset={}, file_len={})",
+        tombstones_offset, index_offset, file_len
+      )));
     }
 
-    /// Load a single record from disk
-    fn load_record(&mut self, key: &K) -> Result<Option<Record<C, V>>, PersistError> {
-        let (offset, length, _version) = match self.index.get(key) {
-            Some(&(o, l, v)) => (o, l, v),
-            None => return Ok(None),
-        };
+    // Load index from end of file
+    reader.seek(SeekFrom::Start(index_offset))?;
+    let index_entries: Vec<IndexEntry<K>> =
+      rmp_serde::from_read(&mut reader).map_err(PersistError::MsgpackDecode)?;
 
-        let reader = match &mut self.file {
-            Some(r) => r,
-            None => return Ok(None),
-        };
+    let index: HashMap<K, (u64, u32, u64)> = index_entries
+      .into_iter()
+      .map(|e| (e.key, (e.offset, e.length, e.highest_version)))
+      .collect();
 
-        reader.seek(SeekFrom::Start(offset))?;
+    // Load tombstones
+    reader.seek(SeekFrom::Start(tombstones_offset))?;
+    let tombstone_map: HashMap<K, TombstoneInfo> =
+      rmp_serde::from_read(&mut reader).map_err(PersistError::MsgpackDecode)?;
 
-        let mut buffer = vec![0u8; length as usize];
-        reader.read_exact(&mut buffer)?;
-
-        let record: Record<C, V> =
-            rmp_serde::from_slice(&buffer).map_err(PersistError::MsgpackDecode)?;
-
-        Ok(Some(record))
+    let mut tombstones = TombstoneStorage::new();
+    for (key, info) in tombstone_map {
+      tombstones.insert_or_assign(key, info);
     }
 
-    /// Check if a key exists in cold storage
-    fn contains_key(&self, key: &K) -> bool {
-        self.index.contains_key(key)
-    }
+    // Store path for on-demand file access (avoids FD exhaustion with many CRDTs)
+    Ok(Self {
+      snapshot_path: Some(path.clone()),
+      index,
+      tombstones,
+      clock_value,
+      _phantom: std::marker::PhantomData,
+    })
+  }
 
-    /// Check if a record is tombstoned
-    fn is_tombstoned(&self, key: &K) -> bool {
-        self.tombstones.find(key).is_some()
-    }
+  /// Load a single record from disk (opens file on-demand)
+  fn load_record(&self, key: &K) -> Result<Option<Record<C, V>>, PersistError> {
+    let (offset, length, _version) = match self.index.get(key) {
+      Some(&(o, l, v)) => (o, l, v),
+      None => return Ok(None),
+    };
 
-    /// Get tombstone info
-    #[allow(dead_code)]
-    fn get_tombstone(&self, key: &K) -> Option<TombstoneInfo> {
-        self.tombstones.find(key)
-    }
+    let path = match &self.snapshot_path {
+      Some(p) => p,
+      None => return Ok(None),
+    };
 
-    /// Iterate over keys (without collecting into Vec to save memory)
-    fn keys(&self) -> impl Iterator<Item = &K> {
-        self.index.keys()
-    }
+    // Open file on-demand, seek to record, read, close
+    // This avoids keeping file descriptors open indefinitely
+    let file = File::open(path)?;
+    let mut reader = BufReader::new(file);
+    reader.seek(SeekFrom::Start(offset))?;
 
-    /// Get keys with changes after a specific version (for efficient sync)
-    fn keys_with_changes_since(&self, last_db_version: u64) -> impl Iterator<Item = &K> {
-        self.index
-            .iter()
-            .filter(move |(_, (_, _, highest_version))| *highest_version > last_db_version)
-            .map(|(k, _)| k)
-    }
+    let mut buffer = vec![0u8; length as usize];
+    reader.read_exact(&mut buffer)?;
 
-    /// Get number of records in cold storage
-    fn len(&self) -> usize {
-        self.index.len()
-    }
+    let record: Record<C, V> =
+      rmp_serde::from_slice(&buffer).map_err(PersistError::MsgpackDecode)?;
+
+    Ok(Some(record))
+  }
+
+  /// Check if a key exists in cold storage
+  fn contains_key(&self, key: &K) -> bool {
+    self.index.contains_key(key)
+  }
+
+  /// Check if a record is tombstoned
+  fn is_tombstoned(&self, key: &K) -> bool {
+    self.tombstones.find(key).is_some()
+  }
+
+  /// Get tombstone info
+  #[allow(dead_code)]
+  fn get_tombstone(&self, key: &K) -> Option<TombstoneInfo> {
+    self.tombstones.find(key)
+  }
+
+  /// Iterate over keys (without collecting into Vec to save memory)
+  fn keys(&self) -> impl Iterator<Item = &K> {
+    self.index.keys()
+  }
+
+  /// Get keys with changes after a specific version (for efficient sync)
+  fn keys_with_changes_since(&self, last_db_version: u64) -> impl Iterator<Item = &K> {
+    self
+      .index
+      .iter()
+      .filter(move |(_, (_, _, highest_version))| *highest_version > last_db_version)
+      .map(|(k, _)| k)
+  }
+
+  /// Get number of records in cold storage
+  fn len(&self) -> usize {
+    self.index.len()
+  }
 }
 
 /// A streaming CRDT that loads records on-demand from disk.
@@ -433,1075 +434,1134 @@ where
 /// indexed snapshot file on-demand.
 pub struct StreamingCRDT<K, C, V>
 where
-    K: Ord + Hash + Eq + Clone,
-    C: Hash + Eq + Clone,
-    V: Clone,
+  K: Ord + Hash + Eq + Clone,
+  C: Hash + Eq + Clone,
+  V: Clone,
 {
-    /// Hot tier: recent changes (always in memory)
-    hot: CRDT<K, C, V>,
-    /// Keys that exist in hot tier (for quick membership check)
-    hot_keys: HashSet<K>,
-    /// Keys that have been tombstoned in hot tier
-    hot_tombstones: HashSet<K>,
+  /// Hot tier: recent changes (always in memory)
+  hot: CRDT<K, C, V>,
+  /// Keys that exist in hot tier (for quick membership check)
+  hot_keys: HashSet<K>,
+  /// Keys that have been tombstoned in hot tier
+  hot_tombstones: HashSet<K>,
 
-    /// Cold tier: on-disk storage with index
-    cold: ColdStorage<K, C, V>,
-    /// LRU cache for cold records
-    cache: LruCache<K, Record<C, V>>,
+  /// Cold tier: on-disk storage with index
+  cold: ColdStorage<K, C, V>,
+  /// LRU cache for cold records
+  cache: LruCache<K, Record<C, V>>,
 
-    /// WAL writer for persistence
-    wal: WalWriter<K, C, V>,
-    /// Configuration
-    config: StreamingConfig,
-    /// Base directory for files
-    base_dir: PathBuf,
+  /// WAL writer for persistence
+  wal: WalWriter<K, C, V>,
+  /// Configuration
+  config: StreamingConfig,
+  /// Base directory for files
+  base_dir: PathBuf,
 
-    /// Changes since last snapshot
-    changes_since_snapshot: usize,
-    /// Current snapshot version
-    snapshot_version: u64,
+  /// Changes since last snapshot
+  changes_since_snapshot: usize,
+  /// Current snapshot version
+  snapshot_version: u64,
 
-    /// Hooks
-    post_hooks: Vec<Box<dyn PostOpHook<K, C, V>>>,
-    snapshot_hooks: Vec<Box<dyn SnapshotHook>>,
-    wal_segment_hooks: Vec<Box<dyn WalSegmentHook>>,
+  /// Hooks
+  post_hooks: Vec<Box<dyn PostOpHook<K, C, V>>>,
+  snapshot_hooks: Vec<Box<dyn SnapshotHook>>,
+  wal_segment_hooks: Vec<Box<dyn WalSegmentHook>>,
 
-    /// Batch collector for network broadcasting
-    batch: Vec<Change<K, C, V>>,
-    /// Last snapshot time
-    last_snapshot_time: std::time::Instant,
+  /// Batch collector for network broadcasting
+  batch: Vec<Change<K, C, V>>,
+  /// Last snapshot time
+  last_snapshot_time: std::time::Instant,
 }
 
 impl<K, C, V> StreamingCRDT<K, C, V>
 where
-    K: Ord + Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
-    C: Ord + Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
-    V: Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+  K: Ord + Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+  C: Ord + Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+  V: Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
 {
-    /// Opens or creates a streaming CRDT at the specified path.
-    ///
-    /// If an indexed snapshot exists, it's opened for lazy loading.
-    /// Otherwise, attempts to migrate from a regular snapshot.
-    pub fn open(
-        base_dir: PathBuf,
-        node_id: NodeId,
-        config: StreamingConfig,
-    ) -> Result<Self, PersistError> {
-        std::fs::create_dir_all(&base_dir)?;
+  /// Opens or creates a streaming CRDT at the specified path.
+  ///
+  /// If an indexed snapshot exists, it's opened for lazy loading.
+  /// Otherwise, attempts to migrate from a regular snapshot.
+  pub fn open(
+    base_dir: PathBuf,
+    node_id: NodeId,
+    config: StreamingConfig,
+  ) -> Result<Self, PersistError> {
+    std::fs::create_dir_all(&base_dir)?;
 
-        // Look for indexed snapshot and extract version
-        let (indexed_snapshot, snapshot_version) = Self::find_indexed_snapshot(&base_dir)?;
+    // Look for indexed snapshot and extract version
+    let (indexed_snapshot, snapshot_version) = Self::find_indexed_snapshot(&base_dir)?;
 
-        let (cold, clock_value, snapshot_version) = if let Some(path) = indexed_snapshot {
-            let cold = ColdStorage::from_file(&path)?;
-            let clock = cold.clock_value;
-            (cold, clock, snapshot_version)
-        } else {
-            // Try to migrate from regular snapshot
-            let migrated = Self::migrate_from_regular_snapshot(&base_dir, node_id)?;
-            if let Some((cold, clock, version)) = migrated {
-                (cold, clock, version)
-            } else {
-                (ColdStorage::empty(), 0, 0)
-            }
-        };
+    let (cold, clock_value, snapshot_version) = if let Some(path) = indexed_snapshot {
+      let cold = ColdStorage::from_file(&path)?;
+      let clock = cold.clock_value;
+      (cold, clock, snapshot_version)
+    } else {
+      // Try to migrate from regular snapshot
+      let migrated = Self::migrate_from_regular_snapshot(&base_dir, node_id)?;
+      if let Some((cold, clock, version)) = migrated {
+        (cold, clock, version)
+      } else {
+        (ColdStorage::empty(), 0, 0)
+      }
+    };
 
-        // Create hot CRDT with clock synced to cold
-        let mut hot = CRDT::new(node_id, None);
-        if clock_value > 0 {
-            // Sync hot clock to cold
-            hot.get_clock_mut().set_time(clock_value);
-        }
-
-        // Create WAL writer
-        let wal = WalWriter::new(base_dir.clone())?;
-
-        // Replay WAL on top of cold storage
-        let mut streaming = Self {
-            hot,
-            hot_keys: HashSet::new(),
-            hot_tombstones: HashSet::new(),
-            cold,
-            cache: LruCache::new(config.cache_capacity),
-            wal,
-            config,
-            base_dir,
-            changes_since_snapshot: 0,
-            snapshot_version,
-            post_hooks: Vec::new(),
-            snapshot_hooks: Vec::new(),
-            wal_segment_hooks: Vec::new(),
-            batch: Vec::new(),
-            last_snapshot_time: std::time::Instant::now(),
-        };
-
-        streaming.replay_wal()?;
-
-        Ok(streaming)
+    // Create hot CRDT with clock synced to cold
+    let mut hot = CRDT::new(node_id, None);
+    if clock_value > 0 {
+      // Sync hot clock to cold
+      hot.get_clock_mut().set_time(clock_value);
     }
 
-    /// Find the most recent indexed snapshot and return its version
-    fn find_indexed_snapshot(base_dir: &PathBuf) -> Result<(Option<PathBuf>, u64), PersistError> {
-        let mut snapshots: Vec<(u64, PathBuf)> = Vec::new();
+    // Create WAL writer
+    let wal = WalWriter::new(base_dir.clone())?;
 
-        if let Ok(entries) = std::fs::read_dir(base_dir) {
-            for entry in entries.flatten() {
-                let filename = entry.file_name();
-                let filename_str = filename.to_string_lossy();
+    // Replay WAL on top of cold storage
+    let mut streaming = Self {
+      hot,
+      hot_keys: HashSet::new(),
+      hot_tombstones: HashSet::new(),
+      cold,
+      cache: LruCache::new(config.cache_capacity),
+      wal,
+      config,
+      base_dir,
+      changes_since_snapshot: 0,
+      snapshot_version,
+      post_hooks: Vec::new(),
+      snapshot_hooks: Vec::new(),
+      wal_segment_hooks: Vec::new(),
+      batch: Vec::new(),
+      last_snapshot_time: std::time::Instant::now(),
+    };
 
-                // Look for indexed snapshots: snapshot_indexed_NNNNNN.bin
-                if filename_str.starts_with("snapshot_indexed_")
-                    && filename_str.ends_with(".bin")
-                {
-                    if let Some(version_str) = filename_str
-                        .strip_prefix("snapshot_indexed_")
-                        .and_then(|s| s.strip_suffix(".bin"))
-                    {
-                        if let Ok(version) = version_str.parse::<u64>() {
-                            snapshots.push((version, entry.path()));
-                        }
-                    }
-                }
+    streaming.replay_wal()?;
+
+    Ok(streaming)
+  }
+
+  /// Find the most recent indexed snapshot and return its version
+  fn find_indexed_snapshot(base_dir: &PathBuf) -> Result<(Option<PathBuf>, u64), PersistError> {
+    let mut snapshots: Vec<(u64, PathBuf)> = Vec::new();
+
+    if let Ok(entries) = std::fs::read_dir(base_dir) {
+      for entry in entries.flatten() {
+        let filename = entry.file_name();
+        let filename_str = filename.to_string_lossy();
+
+        // Look for indexed snapshots: snapshot_indexed_NNNNNN.bin
+        if filename_str.starts_with("snapshot_indexed_") && filename_str.ends_with(".bin") {
+          if let Some(version_str) = filename_str
+            .strip_prefix("snapshot_indexed_")
+            .and_then(|s| s.strip_suffix(".bin"))
+          {
+            if let Ok(version) = version_str.parse::<u64>() {
+              snapshots.push((version, entry.path()));
             }
+          }
         }
-
-        snapshots.sort_by_key(|(v, _)| *v);
-        match snapshots.last() {
-            Some((version, path)) => Ok((Some(path.clone()), *version)),
-            None => Ok((None, 0)),
-        }
+      }
     }
 
-    /// Migrate from a regular PersistedCRDT snapshot to indexed format
-    fn migrate_from_regular_snapshot(
-        base_dir: &PathBuf,
-        node_id: NodeId,
-    ) -> MigrationResult<K, C, V> {
-        // Look for existing MessagePack snapshots
-        let mut snapshots: Vec<(u64, PathBuf)> = Vec::new();
+    snapshots.sort_by_key(|(v, _)| *v);
+    match snapshots.last() {
+      Some((version, path)) => Ok((Some(path.clone()), *version)),
+      None => Ok((None, 0)),
+    }
+  }
 
-        if let Ok(entries) = std::fs::read_dir(base_dir) {
-            for entry in entries.flatten() {
-                let filename = entry.file_name();
-                let filename_str = filename.to_string_lossy();
+  /// Migrate from a regular PersistedCRDT snapshot to indexed format
+  fn migrate_from_regular_snapshot(
+    base_dir: &PathBuf,
+    node_id: NodeId,
+  ) -> MigrationResult<K, C, V> {
+    // Look for existing MessagePack snapshots
+    let mut snapshots: Vec<(u64, PathBuf)> = Vec::new();
 
-                if filename_str.starts_with("snapshot_full_")
-                    && filename_str.ends_with(".msgpack")
-                {
-                    if let Some(version_str) = filename_str
-                        .strip_prefix("snapshot_full_")
-                        .and_then(|s| s.strip_suffix(".msgpack"))
-                    {
-                        if let Ok(version) = version_str.parse::<u64>() {
-                            snapshots.push((version, entry.path()));
-                        }
-                    }
-                }
+    if let Ok(entries) = std::fs::read_dir(base_dir) {
+      for entry in entries.flatten() {
+        let filename = entry.file_name();
+        let filename_str = filename.to_string_lossy();
+
+        if filename_str.starts_with("snapshot_full_") && filename_str.ends_with(".msgpack") {
+          if let Some(version_str) = filename_str
+            .strip_prefix("snapshot_full_")
+            .and_then(|s| s.strip_suffix(".msgpack"))
+          {
+            if let Ok(version) = version_str.parse::<u64>() {
+              snapshots.push((version, entry.path()));
             }
+          }
         }
-
-        if snapshots.is_empty() {
-            return Ok(None);
-        }
-
-        snapshots.sort_by_key(|(v, _)| *v);
-        let (version, path) = snapshots.last().unwrap();
-        let version = *version;
-
-        // Load the regular snapshot
-        let bytes = std::fs::read(path)?;
-
-        // Decompress if needed
-        #[cfg(feature = "compression")]
-        let bytes = if bytes.len() >= 4 && &bytes[0..4] == b"\x28\xb5\x2f\xfd" {
-            zstd::decode_all(&bytes[..]).map_err(PersistError::Compression)?
-        } else {
-            bytes
-        };
-
-        #[cfg(not(feature = "compression"))]
-        let bytes = bytes;
-
-        // Parse header
-        if bytes.len() < 4 {
-            return Ok(None);
-        }
-
-        let metadata_len = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
-        if bytes.len() < 4 + metadata_len {
-            return Ok(None);
-        }
-
-        let crdt_bytes = &bytes[4 + metadata_len..];
-        let crdt: CRDT<K, C, V> =
-            CRDT::from_msgpack_bytes(crdt_bytes).map_err(PersistError::MsgpackDecode)?;
-
-        let clock_value = crdt.get_clock().current_time();
-
-        // Create indexed snapshot from the loaded CRDT (with atomic write)
-        let indexed_path = base_dir.join(format!("snapshot_indexed_{:06}.bin", version));
-        Self::create_indexed_snapshot_from_crdt(&crdt, node_id, &indexed_path)?;
-
-        // Load the new indexed snapshot
-        let cold = ColdStorage::from_file(&indexed_path)?;
-
-        Ok(Some((cold, clock_value, version)))
+      }
     }
 
-    /// Create an indexed snapshot from a CRDT (atomic write via temp file)
-    fn create_indexed_snapshot_from_crdt(
-        crdt: &CRDT<K, C, V>,
-        node_id: NodeId,
-        path: &PathBuf,
-    ) -> Result<(), PersistError> {
-        // Write to a temp file first, then rename atomically
-        let temp_path = path.with_extension("bin.tmp");
-
-        // Use unbuffered I/O to avoid issues with seeking and stream_position
-        let mut file = File::create(&temp_path)?;
-
-        // Write magic and version
-        file.write_all(SNAPSHOT_MAGIC)?;
-        file.write_all(&[SNAPSHOT_VERSION, 0])?; // version, flags
-
-        // Placeholder for header (we'll seek back and write it)
-        let header_pos = file.stream_position()?;
-        let placeholder = vec![0u8; HEADER_SIZE];
-        file.write_all(&placeholder)?;
-
-        // Write records and build index
-        let mut index_entries: Vec<IndexEntry<K>> = Vec::new();
-
-        for (key, record) in crdt.get_data().iter() {
-            let offset = file.stream_position()?;
-            let record_bytes =
-                rmp_serde::to_vec(record).map_err(PersistError::MsgpackEncode)?;
-            file.write_all(&record_bytes)?;
-
-            index_entries.push(IndexEntry {
-                key: key.clone(),
-                offset,
-                length: record_bytes.len() as u32,
-                highest_version: record.highest_local_db_version,
-            });
-        }
-
-        // Write tombstones section
-        let tombstones_offset = file.stream_position()?;
-        let tombstone_map: HashMap<K, TombstoneInfo> = crdt
-            .get_tombstones()
-            .iter()
-            .map(|(k, v)| (k.clone(), *v))
-            .collect();
-        let tombstone_bytes =
-            rmp_serde::to_vec(&tombstone_map).map_err(PersistError::MsgpackEncode)?;
-        file.write_all(&tombstone_bytes)?;
-
-        // Write index section
-        let index_offset = file.stream_position()?;
-        let index_bytes =
-            rmp_serde::to_vec(&index_entries).map_err(PersistError::MsgpackEncode)?;
-        file.write_all(&index_bytes)?;
-
-        // Write header - seek back and overwrite placeholder
-        file.seek(SeekFrom::Start(header_pos))?;
-        file.write_all(&node_id.to_le_bytes())?;
-        file.write_all(&crdt.get_clock().current_time().to_le_bytes())?;
-        file.write_all(&(index_entries.len() as u64).to_le_bytes())?;
-        file.write_all(&(tombstone_map.len() as u64).to_le_bytes())?;
-        file.write_all(&index_offset.to_le_bytes())?;
-        file.write_all(&tombstones_offset.to_le_bytes())?;
-
-        file.sync_all()?;
-        drop(file);
-
-        // Atomic rename
-        std::fs::rename(&temp_path, path)?;
-
-        Ok(())
+    if snapshots.is_empty() {
+      return Ok(None);
     }
 
-    /// Create a streaming snapshot without loading all records into memory.
-    /// Returns the final clock value for the snapshot.
-    fn create_streaming_snapshot(&mut self, path: &PathBuf) -> Result<u64, PersistError> {
-        let temp_path = path.with_extension("bin.tmp");
-        let mut file = File::create(&temp_path)?;
+    snapshots.sort_by_key(|(v, _)| *v);
+    let (version, path) = snapshots.last().unwrap();
+    let version = *version;
 
-        // Write magic and version
-        file.write_all(SNAPSHOT_MAGIC)?;
-        file.write_all(&[SNAPSHOT_VERSION, 0])?;
+    // Load the regular snapshot
+    let bytes = std::fs::read(path)?;
 
-        // Placeholder for header
-        let header_pos = file.stream_position()?;
-        let placeholder = vec![0u8; HEADER_SIZE];
-        file.write_all(&placeholder)?;
+    // Decompress if needed
+    #[cfg(feature = "compression")]
+    let bytes = if bytes.len() >= 4 && &bytes[0..4] == b"\x28\xb5\x2f\xfd" {
+      zstd::decode_all(&bytes[..]).map_err(PersistError::Compression)?
+    } else {
+      bytes
+    };
 
-        // Track highest clock value seen
-        let mut max_clock = self.hot.get_clock().current_time();
-
-        // Build index as we write
-        let mut index_entries: Vec<IndexEntry<K>> = Vec::new();
-
-        // 1. Stream cold records that are NOT superseded by hot tier
-        //    This avoids loading all cold records into memory
-        for key in self.cold.keys().cloned().collect::<Vec<_>>() {
-            // Skip if hot has this key (hot data supersedes cold)
-            if self.hot_keys.contains(&key) {
-                continue;
-            }
-            // Skip if tombstoned in hot
-            if self.hot_tombstones.contains(&key) {
-                continue;
-            }
-
-            // Load and write individual record (only one in memory at a time)
-            if let Some(record) = self.cold.load_record(&key)? {
-                max_clock = max_clock.max(record.highest_local_db_version);
-
-                let offset = file.stream_position()?;
-                let record_bytes = rmp_serde::to_vec(&record)
-                    .map_err(PersistError::MsgpackEncode)?;
-                file.write_all(&record_bytes)?;
-
-                index_entries.push(IndexEntry {
-                    key,
-                    offset,
-                    length: record_bytes.len() as u32,
-                    highest_version: record.highest_local_db_version,
-                });
-            }
-        }
-
-        // 2. Write hot tier records (already in memory, no extra load)
-        for (key, record) in self.hot.get_data().iter() {
-            max_clock = max_clock.max(record.highest_local_db_version);
-
-            let offset = file.stream_position()?;
-            let record_bytes = rmp_serde::to_vec(record)
-                .map_err(PersistError::MsgpackEncode)?;
-            file.write_all(&record_bytes)?;
-
-            index_entries.push(IndexEntry {
-                key: key.clone(),
-                offset,
-                length: record_bytes.len() as u32,
-                highest_version: record.highest_local_db_version,
-            });
-        }
-
-        // 3. Merge tombstones from cold and hot
-        let mut tombstone_map: HashMap<K, TombstoneInfo> = HashMap::new();
-
-        // Add cold tombstones not superseded by hot
-        for (key, info) in self.cold.tombstones.iter() {
-            if !self.hot_keys.contains(key) {
-                tombstone_map.insert(key.clone(), *info);
-            }
-        }
-
-        // Add hot tombstones
-        for key in &self.hot_tombstones {
-            if let Some(info) = self.hot.get_tombstones().find(key) {
-                tombstone_map.insert(key.clone(), info);
-            }
-        }
-
-        // Write tombstones section
-        let tombstones_offset = file.stream_position()?;
-        let tombstone_bytes = rmp_serde::to_vec(&tombstone_map)
-            .map_err(PersistError::MsgpackEncode)?;
-        file.write_all(&tombstone_bytes)?;
-
-        // Write index section
-        let index_offset = file.stream_position()?;
-        let index_bytes = rmp_serde::to_vec(&index_entries)
-            .map_err(PersistError::MsgpackEncode)?;
-        file.write_all(&index_bytes)?;
-
-        // Write header
-        file.seek(SeekFrom::Start(header_pos))?;
-        file.write_all(&self.hot.node_id.to_le_bytes())?;
-        file.write_all(&max_clock.to_le_bytes())?;
-        file.write_all(&(index_entries.len() as u64).to_le_bytes())?;
-        file.write_all(&(tombstone_map.len() as u64).to_le_bytes())?;
-        file.write_all(&index_offset.to_le_bytes())?;
-        file.write_all(&tombstones_offset.to_le_bytes())?;
-
-        file.sync_all()?;
-        drop(file);
-
-        // Atomic rename
-        std::fs::rename(&temp_path, path)?;
-
-        Ok(max_clock)
+    // Parse header
+    if bytes.len() < 4 {
+      return Ok(None);
     }
 
-    /// Replay WAL files on top of current state
-    fn replay_wal(&mut self) -> Result<(), PersistError> {
-        let mut wal_files: Vec<_> = std::fs::read_dir(&self.base_dir)?
-            .filter_map(|e| e.ok())
-            .filter(|e| {
-                let name = e.file_name().to_string_lossy().to_string();
-                name.starts_with("wal_") && name.ends_with(".bin")
-            })
-            .collect();
+    let metadata_len = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
+    if bytes.len() < 4 + metadata_len {
+      return Ok(None);
+    }
 
-        wal_files.sort_by_key(|e| {
-            e.file_name()
-                .to_string_lossy()
-                .strip_prefix("wal_")
-                .and_then(|s| s.strip_suffix(".bin"))
-                .and_then(|n| n.parse::<u64>().ok())
-                .unwrap_or(0)
+    let crdt_bytes = &bytes[4 + metadata_len..];
+    let crdt: CRDT<K, C, V> =
+      CRDT::from_msgpack_bytes(crdt_bytes).map_err(PersistError::MsgpackDecode)?;
+
+    let clock_value = crdt.get_clock().current_time();
+
+    // Create indexed snapshot from the loaded CRDT (with atomic write)
+    let indexed_path = base_dir.join(format!("snapshot_indexed_{:06}.bin", version));
+    Self::create_indexed_snapshot_from_crdt(&crdt, node_id, &indexed_path)?;
+
+    // Load the new indexed snapshot
+    let cold = ColdStorage::from_file(&indexed_path)?;
+
+    Ok(Some((cold, clock_value, version)))
+  }
+
+  /// Create an indexed snapshot from a CRDT (atomic write via temp file)
+  fn create_indexed_snapshot_from_crdt(
+    crdt: &CRDT<K, C, V>,
+    node_id: NodeId,
+    path: &PathBuf,
+  ) -> Result<(), PersistError> {
+    // Write to a temp file first, then rename atomically
+    let temp_path = path.with_extension("bin.tmp");
+
+    // Use unbuffered I/O to avoid issues with seeking and stream_position
+    let mut file = File::create(&temp_path)?;
+
+    // Write magic and version
+    file.write_all(SNAPSHOT_MAGIC)?;
+    file.write_all(&[SNAPSHOT_VERSION, 0])?; // version, flags
+
+    // Placeholder for header (we'll seek back and write it)
+    let header_pos = file.stream_position()?;
+    let placeholder = vec![0u8; HEADER_SIZE];
+    file.write_all(&placeholder)?;
+
+    // Write records and build index
+    let mut index_entries: Vec<IndexEntry<K>> = Vec::new();
+
+    for (key, record) in crdt.get_data().iter() {
+      let offset = file.stream_position()?;
+      let record_bytes = rmp_serde::to_vec(record).map_err(PersistError::MsgpackEncode)?;
+      file.write_all(&record_bytes)?;
+
+      index_entries.push(IndexEntry {
+        key: key.clone(),
+        offset,
+        length: record_bytes.len() as u32,
+        highest_version: record.highest_local_db_version,
+      });
+    }
+
+    // Write tombstones section
+    let tombstones_offset = file.stream_position()?;
+    let tombstone_map: HashMap<K, TombstoneInfo> = crdt
+      .get_tombstones()
+      .iter()
+      .map(|(k, v)| (k.clone(), *v))
+      .collect();
+    let tombstone_bytes = rmp_serde::to_vec(&tombstone_map).map_err(PersistError::MsgpackEncode)?;
+    file.write_all(&tombstone_bytes)?;
+
+    // Write index section
+    let index_offset = file.stream_position()?;
+    let index_bytes = rmp_serde::to_vec(&index_entries).map_err(PersistError::MsgpackEncode)?;
+    file.write_all(&index_bytes)?;
+
+    // Write header - seek back and overwrite placeholder
+    file.seek(SeekFrom::Start(header_pos))?;
+    file.write_all(&node_id.to_le_bytes())?;
+    file.write_all(&crdt.get_clock().current_time().to_le_bytes())?;
+    file.write_all(&(index_entries.len() as u64).to_le_bytes())?;
+    file.write_all(&(tombstone_map.len() as u64).to_le_bytes())?;
+    file.write_all(&index_offset.to_le_bytes())?;
+    file.write_all(&tombstones_offset.to_le_bytes())?;
+
+    file.sync_all()?;
+    drop(file);
+
+    // Atomic rename
+    std::fs::rename(&temp_path, path)?;
+
+    Ok(())
+  }
+
+  /// Create a streaming snapshot without loading all records into memory.
+  /// Returns the final clock value for the snapshot.
+  fn create_streaming_snapshot(&mut self, path: &PathBuf) -> Result<u64, PersistError> {
+    let temp_path = path.with_extension("bin.tmp");
+    let mut file = File::create(&temp_path)?;
+
+    // Write magic and version
+    file.write_all(SNAPSHOT_MAGIC)?;
+    file.write_all(&[SNAPSHOT_VERSION, 0])?;
+
+    // Placeholder for header
+    let header_pos = file.stream_position()?;
+    let placeholder = vec![0u8; HEADER_SIZE];
+    file.write_all(&placeholder)?;
+
+    // Track highest clock value seen
+    let mut max_clock = self.hot.get_clock().current_time();
+
+    // Build index as we write
+    let mut index_entries: Vec<IndexEntry<K>> = Vec::new();
+
+    // 1. Stream cold records that are NOT superseded by hot tier
+    //    This avoids loading all cold records into memory
+    for key in self.cold.keys().cloned().collect::<Vec<_>>() {
+      // Skip if hot has this key (hot data supersedes cold)
+      if self.hot_keys.contains(&key) {
+        continue;
+      }
+      // Skip if tombstoned in hot
+      if self.hot_tombstones.contains(&key) {
+        continue;
+      }
+
+      // Load and write individual record (only one in memory at a time)
+      if let Some(record) = self.cold.load_record(&key)? {
+        max_clock = max_clock.max(record.highest_local_db_version);
+
+        let offset = file.stream_position()?;
+        let record_bytes = rmp_serde::to_vec(&record).map_err(PersistError::MsgpackEncode)?;
+        file.write_all(&record_bytes)?;
+
+        index_entries.push(IndexEntry {
+          key,
+          offset,
+          length: record_bytes.len() as u32,
+          highest_version: record.highest_local_db_version,
         });
-
-        for entry in wal_files {
-            let changes: Vec<Change<K, C, V>> = super::wal::read_wal_file(&entry.path())?;
-            let num_changes = changes.len();
-            for change in &changes {
-                // Apply to hot tier
-                self.hot_keys.insert(change.record_id.clone());
-                if change.col_name.is_none() {
-                    self.hot_tombstones.insert(change.record_id.clone());
-                }
-            }
-            // Merge the changes
-            self.hot.merge_changes(changes, &DefaultMergeRule);
-            self.changes_since_snapshot += num_changes; // Fix: count actual changes
-        }
-
-        Ok(())
+      }
     }
 
-    /// Get a record, checking hot tier first, then cache, then cold storage
-    pub fn get_record(&mut self, key: &K) -> Result<Option<Record<C, V>>, PersistError> {
-        // 1. Check hot tier first (most recent)
-        if self.hot_keys.contains(key) {
-            if let Some(record) = self.hot.get_record(key) {
-                return Ok(Some(record.clone()));
-            }
-            // Key is in hot but record was deleted
-            if self.hot_tombstones.contains(key) {
-                return Ok(None);
-            }
-        }
+    // 2. Write hot tier records (already in memory, no extra load)
+    for (key, record) in self.hot.get_data().iter() {
+      max_clock = max_clock.max(record.highest_local_db_version);
 
-        // 2. Check if tombstoned (hot or cold)
-        if self.hot_tombstones.contains(key) || self.cold.is_tombstoned(key) {
-            return Ok(None);
-        }
+      let offset = file.stream_position()?;
+      let record_bytes = rmp_serde::to_vec(record).map_err(PersistError::MsgpackEncode)?;
+      file.write_all(&record_bytes)?;
 
-        // 3. Check LRU cache
-        if let Some(record) = self.cache.get(key) {
-            return Ok(Some(record.clone()));
-        }
-
-        // 4. Load from cold storage
-        if let Some(record) = self.cold.load_record(key)? {
-            self.cache.insert(key.clone(), record.clone());
-            return Ok(Some(record));
-        }
-
-        Ok(None)
+      index_entries.push(IndexEntry {
+        key: key.clone(),
+        offset,
+        length: record_bytes.len() as u32,
+        highest_version: record.highest_local_db_version,
+      });
     }
 
-    /// Check if a record exists (without loading full record)
-    pub fn contains_key(&self, key: &K) -> bool {
-        if self.hot_tombstones.contains(key) || self.cold.is_tombstoned(key) {
-            return false;
-        }
-        self.hot_keys.contains(key) || self.cache.contains_key(key) || self.cold.contains_key(key)
+    // 3. Merge tombstones from cold and hot
+    let mut tombstone_map: HashMap<K, TombstoneInfo> = HashMap::new();
+
+    // Add cold tombstones not superseded by hot
+    for (key, info) in self.cold.tombstones.iter() {
+      if !self.hot_keys.contains(key) {
+        tombstone_map.insert(key.clone(), *info);
+      }
     }
 
-    /// Check if a record is tombstoned
-    pub fn is_tombstoned(&self, key: &K) -> bool {
-        self.hot_tombstones.contains(key) || self.cold.is_tombstoned(key)
+    // Add hot tombstones
+    for key in &self.hot_tombstones {
+      if let Some(info) = self.hot.get_tombstones().find(key) {
+        tombstone_map.insert(key.clone(), info);
+      }
     }
 
-    /// Insert or update a record
-    pub fn insert_or_update<I>(
-        &mut self,
-        record_id: &K,
-        fields: I,
-    ) -> Result<Vec<Change<K, C, V>>, PersistError>
-    where
-        I: IntoIterator<Item = (C, V)>,
-    {
-        // Check tombstones
-        if self.is_tombstoned(record_id) {
-            return Ok(Vec::new());
-        }
+    // Write tombstones section
+    let tombstones_offset = file.stream_position()?;
+    let tombstone_bytes = rmp_serde::to_vec(&tombstone_map).map_err(PersistError::MsgpackEncode)?;
+    file.write_all(&tombstone_bytes)?;
 
-        // If record exists in cold but not hot, load it first
-        if !self.hot_keys.contains(record_id) && self.cold.contains_key(record_id) {
-            if let Some(cold_record) = self.cold.load_record(record_id)? {
-                // Directly insert cold record into hot storage (preserves version metadata)
-                self.hot.insert_record_direct(record_id.clone(), cold_record);
-                self.hot_keys.insert(record_id.clone());
-            }
-        }
+    // Write index section
+    let index_offset = file.stream_position()?;
+    let index_bytes = rmp_serde::to_vec(&index_entries).map_err(PersistError::MsgpackEncode)?;
+    file.write_all(&index_bytes)?;
 
+    // Write header
+    file.seek(SeekFrom::Start(header_pos))?;
+    file.write_all(&self.hot.node_id.to_le_bytes())?;
+    file.write_all(&max_clock.to_le_bytes())?;
+    file.write_all(&(index_entries.len() as u64).to_le_bytes())?;
+    file.write_all(&(tombstone_map.len() as u64).to_le_bytes())?;
+    file.write_all(&index_offset.to_le_bytes())?;
+    file.write_all(&tombstones_offset.to_le_bytes())?;
+
+    file.sync_all()?;
+    drop(file);
+
+    // Atomic rename
+    std::fs::rename(&temp_path, path)?;
+
+    Ok(max_clock)
+  }
+
+  /// Replay WAL files on top of current state
+  fn replay_wal(&mut self) -> Result<(), PersistError> {
+    let mut wal_files: Vec<_> = std::fs::read_dir(&self.base_dir)?
+      .filter_map(|e| e.ok())
+      .filter(|e| {
+        let name = e.file_name().to_string_lossy().to_string();
+        name.starts_with("wal_") && name.ends_with(".bin")
+      })
+      .collect();
+
+    wal_files.sort_by_key(|e| {
+      e.file_name()
+        .to_string_lossy()
+        .strip_prefix("wal_")
+        .and_then(|s| s.strip_suffix(".bin"))
+        .and_then(|n| n.parse::<u64>().ok())
+        .unwrap_or(0)
+    });
+
+    for entry in wal_files {
+      let changes: Vec<Change<K, C, V>> = super::wal::read_wal_file(&entry.path())?;
+      let num_changes = changes.len();
+      for change in &changes {
         // Apply to hot tier
-        let changes = self.hot.insert_or_update(record_id, fields);
+        self.hot_keys.insert(change.record_id.clone());
+        if change.col_name.is_none() {
+          self.hot_tombstones.insert(change.record_id.clone());
+        }
+      }
+      // Merge the changes
+      self.hot.merge_changes(changes, &DefaultMergeRule);
+      self.changes_since_snapshot += num_changes; // Fix: count actual changes
+    }
+
+    Ok(())
+  }
+
+  /// Get a record, checking hot tier first, then cache, then cold storage
+  pub fn get_record(&mut self, key: &K) -> Result<Option<Record<C, V>>, PersistError> {
+    // 1. Check hot tier first (most recent)
+    if self.hot_keys.contains(key) {
+      if let Some(record) = self.hot.get_record(key) {
+        return Ok(Some(record.clone()));
+      }
+      // Key is in hot but record was deleted
+      if self.hot_tombstones.contains(key) {
+        return Ok(None);
+      }
+    }
+
+    // 2. Check if tombstoned (hot or cold)
+    if self.hot_tombstones.contains(key) || self.cold.is_tombstoned(key) {
+      return Ok(None);
+    }
+
+    // 3. Check LRU cache
+    if let Some(record) = self.cache.get(key) {
+      return Ok(Some(record.clone()));
+    }
+
+    // 4. Load from cold storage
+    if let Some(record) = self.cold.load_record(key)? {
+      self.cache.insert(key.clone(), record.clone());
+      return Ok(Some(record));
+    }
+
+    Ok(None)
+  }
+
+  /// Check if a record exists (without loading full record)
+  pub fn contains_key(&self, key: &K) -> bool {
+    if self.hot_tombstones.contains(key) || self.cold.is_tombstoned(key) {
+      return false;
+    }
+    self.hot_keys.contains(key) || self.cache.contains_key(key) || self.cold.contains_key(key)
+  }
+
+  /// Check if a record is tombstoned
+  pub fn is_tombstoned(&self, key: &K) -> bool {
+    self.hot_tombstones.contains(key) || self.cold.is_tombstoned(key)
+  }
+
+  /// Insert or update a record
+  pub fn insert_or_update<I>(
+    &mut self,
+    record_id: &K,
+    fields: I,
+  ) -> Result<Vec<Change<K, C, V>>, PersistError>
+  where
+    I: IntoIterator<Item = (C, V)>,
+  {
+    // Check tombstones
+    if self.is_tombstoned(record_id) {
+      return Ok(Vec::new());
+    }
+
+    // If record exists in cold but not hot, load it first
+    if !self.hot_keys.contains(record_id) && self.cold.contains_key(record_id) {
+      if let Some(cold_record) = self.cold.load_record(record_id)? {
+        // Directly insert cold record into hot storage (preserves version metadata)
+        self
+          .hot
+          .insert_record_direct(record_id.clone(), cold_record);
         self.hot_keys.insert(record_id.clone());
-
-        // Persist
-        self.persist_and_notify(&changes)?;
-
-        Ok(changes)
+      }
     }
 
-    /// Delete a record
-    pub fn delete_record(&mut self, record_id: &K) -> Result<Option<Change<K, C, V>>, PersistError> {
-        if self.is_tombstoned(record_id) {
-            return Ok(None);
-        }
+    // Apply to hot tier
+    let changes = self.hot.insert_or_update(record_id, fields);
+    self.hot_keys.insert(record_id.clone());
 
-        let change = self.hot.delete_record(record_id);
-        if let Some(ref c) = change {
-            self.hot_tombstones.insert(record_id.clone());
-            self.persist_and_notify(std::slice::from_ref(c))?;
-        }
+    // Persist
+    self.persist_and_notify(&changes)?;
 
-        Ok(change)
+    Ok(changes)
+  }
+
+  /// Delete a record
+  pub fn delete_record(&mut self, record_id: &K) -> Result<Option<Change<K, C, V>>, PersistError> {
+    if self.is_tombstoned(record_id) {
+      return Ok(None);
     }
 
-    /// Merge changes from remote nodes
-    pub fn merge_changes(
-        &mut self,
-        changes: Vec<Change<K, C, V>>,
-    ) -> Result<Vec<Change<K, C, V>>, PersistError> {
-        // Load any cold records that are being updated
-        for change in &changes {
-            if !self.hot_keys.contains(&change.record_id)
-                && self.cold.contains_key(&change.record_id)
-            {
-                if let Some(cold_record) = self.cold.load_record(&change.record_id)? {
-                    // Directly insert cold record into hot storage (preserves version metadata)
-                    self.hot.insert_record_direct(change.record_id.clone(), cold_record);
-                    self.hot_keys.insert(change.record_id.clone());
-                }
-            }
-        }
-
-        // Apply to hot tier
-        let accepted = self.hot.merge_changes(changes, &DefaultMergeRule);
-
-        // Track keys
-        for change in &accepted {
-            self.hot_keys.insert(change.record_id.clone());
-            if change.col_name.is_none() {
-                self.hot_tombstones.insert(change.record_id.clone());
-            }
-        }
-
-        // Persist
-        self.persist_and_notify(&accepted)?;
-
-        Ok(accepted)
+    let change = self.hot.delete_record(record_id);
+    if let Some(ref c) = change {
+      self.hot_tombstones.insert(record_id.clone());
+      self.persist_and_notify(std::slice::from_ref(c))?;
     }
 
-    /// Get changes since a version (for sync)
-    ///
-    /// This scans both hot and cold storage to ensure all changes are included.
-    ///
-    /// # Performance
-    ///
-    /// Uses an indexed lookup to find cold records with changes after `last_db_version`,
-    /// avoiding a full scan of all records. Only records that actually have changes
-    /// after the specified version are loaded from disk.
-    ///
-    /// For optimal performance, call `get_changes_since` with the highest version
-    /// you've already synced to minimize the number of records loaded.
-    pub fn get_changes_since(&mut self, last_db_version: u64) -> Result<Vec<Change<K, C, V>>, PersistError> {
-        // Hot tier changes
-        let mut changes = self.hot.get_changes_since(last_db_version);
+    Ok(change)
+  }
 
-        // Use indexed lookup for cold records with changes after last_db_version
-        // This avoids scanning ALL cold records - only those with matching versions
-        let cold_keys_to_check: Vec<K> = self.cold
-            .keys_with_changes_since(last_db_version)
-            .filter(|k| !self.hot_keys.contains(*k) && !self.hot_tombstones.contains(*k))
-            .cloned()
-            .collect();
-
-        for key in cold_keys_to_check {
-            if let Some(record) = self.cold.load_record(&key)? {
-                // Convert record to changes
-                for (col_name, value) in &record.fields {
-                    if let Some(col_ver) = record.column_versions.get(col_name) {
-                        if col_ver.local_db_version > last_db_version {
-                            changes.push(Change::new(
-                                key.clone(),
-                                Some(col_name.clone()),
-                                Some(value.clone()),
-                                col_ver.col_version,
-                                col_ver.db_version,
-                                col_ver.node_id,
-                                col_ver.local_db_version,
-                                0,
-                            ));
-                        }
-                    }
-                }
-            }
+  /// Merge changes from remote nodes
+  pub fn merge_changes(
+    &mut self,
+    changes: Vec<Change<K, C, V>>,
+  ) -> Result<Vec<Change<K, C, V>>, PersistError> {
+    // Load any cold records that are being updated
+    for change in &changes {
+      if !self.hot_keys.contains(&change.record_id) && self.cold.contains_key(&change.record_id) {
+        if let Some(cold_record) = self.cold.load_record(&change.record_id)? {
+          // Directly insert cold record into hot storage (preserves version metadata)
+          self
+            .hot
+            .insert_record_direct(change.record_id.clone(), cold_record);
+          self.hot_keys.insert(change.record_id.clone());
         }
-
-        // Include cold tombstones if they're after last_db_version
-        // Skip if hot has already tombstoned or touched this key
-        for (key, info) in self.cold.tombstones.iter() {
-            if info.local_db_version > last_db_version
-                && !self.hot_keys.contains(key)
-                && !self.hot_tombstones.contains(key)
-            {
-                changes.push(Change::new(
-                    key.clone(),
-                    None,
-                    None,
-                    u64::MAX,
-                    info.db_version,
-                    info.node_id,
-                    info.local_db_version,
-                    0,
-                ));
-            }
-        }
-
-        // Sort and dedupe
-        CRDT::compress_changes(&mut changes);
-
-        Ok(changes)
+      }
     }
 
-    /// Create an indexed snapshot of current state
-    ///
-    /// This streams records directly to the snapshot file without loading all
-    /// cold records into memory, making it suitable for large datasets.
-    pub fn create_indexed_snapshot(&mut self) -> Result<PathBuf, PersistError> {
-        self.snapshot_version += 1;
-        let snapshot_path = self.base_dir.join(format!(
-            "snapshot_indexed_{:06}.bin",
-            self.snapshot_version
+    // Apply to hot tier
+    let accepted = self.hot.merge_changes(changes, &DefaultMergeRule);
+
+    // Track keys
+    for change in &accepted {
+      self.hot_keys.insert(change.record_id.clone());
+      if change.col_name.is_none() {
+        self.hot_tombstones.insert(change.record_id.clone());
+      }
+    }
+
+    // Persist
+    self.persist_and_notify(&accepted)?;
+
+    Ok(accepted)
+  }
+
+  /// Get changes since a version (for sync)
+  ///
+  /// This scans both hot and cold storage to ensure all changes are included.
+  ///
+  /// # Performance
+  ///
+  /// Uses an indexed lookup to find cold records with changes after `last_db_version`,
+  /// avoiding a full scan of all records. Only records that actually have changes
+  /// after the specified version are loaded from disk.
+  ///
+  /// For optimal performance, call `get_changes_since` with the highest version
+  /// you've already synced to minimize the number of records loaded.
+  pub fn get_changes_since(
+    &mut self,
+    last_db_version: u64,
+  ) -> Result<Vec<Change<K, C, V>>, PersistError> {
+    // Hot tier changes
+    let mut changes = self.hot.get_changes_since(last_db_version);
+
+    // Use indexed lookup for cold records with changes after last_db_version
+    // This avoids scanning ALL cold records - only those with matching versions
+    let cold_keys_to_check: Vec<K> = self
+      .cold
+      .keys_with_changes_since(last_db_version)
+      .filter(|k| !self.hot_keys.contains(*k) && !self.hot_tombstones.contains(*k))
+      .cloned()
+      .collect();
+
+    for key in cold_keys_to_check {
+      if let Some(record) = self.cold.load_record(&key)? {
+        // Convert record to changes
+        for (col_name, value) in &record.fields {
+          if let Some(col_ver) = record.column_versions.get(col_name) {
+            if col_ver.local_db_version > last_db_version {
+              changes.push(Change::new(
+                key.clone(),
+                Some(col_name.clone()),
+                Some(value.clone()),
+                col_ver.col_version,
+                col_ver.db_version,
+                col_ver.node_id,
+                col_ver.local_db_version,
+                0,
+              ));
+            }
+          }
+        }
+      }
+    }
+
+    // Include cold tombstones if they're after last_db_version
+    // Skip if hot has already tombstoned or touched this key
+    for (key, info) in self.cold.tombstones.iter() {
+      if info.local_db_version > last_db_version
+        && !self.hot_keys.contains(key)
+        && !self.hot_tombstones.contains(key)
+      {
+        changes.push(Change::new(
+          key.clone(),
+          None,
+          None,
+          u64::MAX,
+          info.db_version,
+          info.node_id,
+          info.local_db_version,
+          0,
         ));
+      }
+    }
 
-        // Stream snapshot directly to file (avoids memory explosion)
-        let final_clock_value = self.create_streaming_snapshot(&snapshot_path)?;
+    // Sort and dedupe
+    CRDT::compress_changes(&mut changes);
 
-        // Reload cold storage from new snapshot
-        self.cold = ColdStorage::from_file(&snapshot_path)?;
+    Ok(changes)
+  }
 
-        // Clear hot tier with final clock value
-        self.hot = CRDT::new(self.hot.node_id, None);
-        self.hot.get_clock_mut().set_time(final_clock_value);
-        self.hot_keys.clear();
-        self.hot_tombstones.clear();
-        self.cache = LruCache::new(self.config.cache_capacity);
+  /// Create an indexed snapshot of current state
+  ///
+  /// This streams records directly to the snapshot file without loading all
+  /// cold records into memory, making it suitable for large datasets.
+  pub fn create_indexed_snapshot(&mut self) -> Result<PathBuf, PersistError> {
+    self.snapshot_version += 1;
+    let snapshot_path = self
+      .base_dir
+      .join(format!("snapshot_indexed_{:06}.bin", self.snapshot_version));
 
-        // Rotate WAL and delete old segments (snapshot has all data)
-        let _ = self.wal.rotate(&self.base_dir, &self.wal_segment_hooks)?;
-        self.cleanup_old_wal_files()?;
+    // Stream snapshot directly to file (avoids memory explosion)
+    let final_clock_value = self.create_streaming_snapshot(&snapshot_path)?;
 
-        // Reset counters
-        self.changes_since_snapshot = 0;
-        self.last_snapshot_time = std::time::Instant::now();
+    // Reload cold storage from new snapshot
+    self.cold = ColdStorage::from_file(&snapshot_path)?;
 
-        // Call hooks
-        let db_version = self.cold.clock_value;
-        for hook in &self.snapshot_hooks {
-            hook.on_snapshot(&snapshot_path, db_version);
+    // Clear hot tier with final clock value
+    self.hot = CRDT::new(self.hot.node_id, None);
+    self.hot.get_clock_mut().set_time(final_clock_value);
+    self.hot_keys.clear();
+    self.hot_tombstones.clear();
+    self.cache = LruCache::new(self.config.cache_capacity);
+
+    // Rotate WAL and delete old segments (snapshot has all data)
+    let _ = self.wal.rotate(&self.base_dir, &self.wal_segment_hooks)?;
+    self.cleanup_old_wal_files()?;
+
+    // Reset counters
+    self.changes_since_snapshot = 0;
+    self.last_snapshot_time = std::time::Instant::now();
+
+    // Call hooks
+    let db_version = self.cold.clock_value;
+    for hook in &self.snapshot_hooks {
+      hook.on_snapshot(&snapshot_path, db_version);
+    }
+
+    Ok(snapshot_path)
+  }
+
+  /// Get the batch of changes for network broadcasting
+  pub fn take_batch(&mut self) -> Vec<Change<K, C, V>> {
+    std::mem::take(&mut self.batch)
+  }
+
+  /// Compact tombstones older than the specified version.
+  ///
+  /// **CRITICAL**: Only call this after ALL nodes have acknowledged the version.
+  /// Premature compaction can cause deleted records to reappear (zombie records).
+  ///
+  /// This creates a new snapshot with compacted tombstones, then reloads cold storage.
+  ///
+  /// # Arguments
+  ///
+  /// * `min_acknowledged_version` - The minimum version acknowledged by all nodes.
+  ///   Tombstones with `local_db_version <= min_acknowledged_version` will be removed.
+  ///
+  /// # Returns
+  ///
+  /// The number of tombstones removed.
+  pub fn compact_tombstones(
+    &mut self,
+    min_acknowledged_version: u64,
+  ) -> Result<usize, PersistError> {
+    // Compact hot tier tombstones
+    let hot_compacted = self.hot.compact_tombstones(min_acknowledged_version);
+
+    // Remove from hot_tombstones tracking set for compacted tombstones
+    let keys_to_remove: Vec<K> = self
+      .hot_tombstones
+      .iter()
+      .filter(|k| {
+        if let Some(info) = self.hot.get_tombstones().find(*k) {
+          false // Still exists, don't remove from tracking
+        } else {
+          true // Was compacted, remove from tracking
         }
+      })
+      .cloned()
+      .collect();
 
-        Ok(snapshot_path)
+    for key in keys_to_remove {
+      self.hot_tombstones.remove(&key);
     }
 
-    /// Get the batch of changes for network broadcasting
-    pub fn take_batch(&mut self) -> Vec<Change<K, C, V>> {
-        std::mem::take(&mut self.batch)
+    // Count cold tombstones that will be compacted
+    let cold_to_compact: usize = self
+      .cold
+      .tombstones
+      .iter()
+      .filter(|(_, info)| info.local_db_version <= min_acknowledged_version)
+      .count();
+
+    // If there are cold tombstones to compact, create new snapshot
+    if cold_to_compact > 0 {
+      // Force snapshot which will merge tombstones and apply compaction
+      self.create_indexed_snapshot()?;
+
+      // Now compact the reloaded cold storage tombstones
+      self.cold.tombstones.compact(min_acknowledged_version);
     }
 
-    /// Add a post-operation hook
-    pub fn add_post_hook(&mut self, hook: Box<dyn PostOpHook<K, C, V>>) {
-        self.post_hooks.push(hook);
-    }
+    Ok(hot_compacted + cold_to_compact)
+  }
 
-    /// Add a snapshot hook
-    pub fn add_snapshot_hook(&mut self, hook: Box<dyn SnapshotHook>) {
-        self.snapshot_hooks.push(hook);
-    }
+  /// Add a post-operation hook
+  pub fn add_post_hook(&mut self, hook: Box<dyn PostOpHook<K, C, V>>) {
+    self.post_hooks.push(hook);
+  }
 
-    /// Add a WAL segment hook
-    pub fn add_wal_segment_hook(&mut self, hook: Box<dyn WalSegmentHook>) {
-        self.wal_segment_hooks.push(hook);
-    }
+  /// Add a snapshot hook
+  pub fn add_snapshot_hook(&mut self, hook: Box<dyn SnapshotHook>) {
+    self.snapshot_hooks.push(hook);
+  }
 
-    /// Get number of records in hot tier
-    pub fn hot_record_count(&self) -> usize {
-        self.hot_keys.len()
-    }
+  /// Add a WAL segment hook
+  pub fn add_wal_segment_hook(&mut self, hook: Box<dyn WalSegmentHook>) {
+    self.wal_segment_hooks.push(hook);
+  }
 
-    /// Get number of records in cold storage
-    pub fn cold_record_count(&self) -> usize {
-        self.cold.len()
-    }
+  /// Get number of records in hot tier
+  pub fn hot_record_count(&self) -> usize {
+    self.hot_keys.len()
+  }
 
-    /// Get total number of active records (hot + cold, excluding duplicates and tombstones)
-    ///
-    /// Note: Records in hot tier that supersede cold records are counted once.
-    /// Tombstoned records are not counted.
-    pub fn total_record_count(&self) -> usize {
-        // Cold records not in hot and not tombstoned
-        let cold_only = self.cold.index.keys()
-            .filter(|k| !self.hot_keys.contains(*k) && !self.hot_tombstones.contains(*k))
-            .filter(|k| !self.cold.is_tombstoned(*k))
-            .count();
-        // Hot records minus hot tombstones
-        let hot_active = self.hot_keys.len().saturating_sub(self.hot_tombstones.len());
-        cold_only + hot_active
-    }
+  /// Get number of records in cold storage
+  pub fn cold_record_count(&self) -> usize {
+    self.cold.len()
+  }
 
-    /// Get current logical clock value
-    pub fn get_clock_time(&self) -> u64 {
-        self.hot.get_clock().current_time()
-    }
+  /// Get total number of active records (hot + cold, excluding duplicates and tombstones)
+  ///
+  /// Note: Records in hot tier that supersede cold records are counted once.
+  /// Tombstoned records are not counted.
+  pub fn total_record_count(&self) -> usize {
+    // Cold records not in hot and not tombstoned
+    let cold_only = self
+      .cold
+      .index
+      .keys()
+      .filter(|k| !self.hot_keys.contains(*k) && !self.hot_tombstones.contains(*k))
+      .filter(|k| !self.cold.is_tombstoned(*k))
+      .count();
+    // Hot records minus hot tombstones
+    let hot_active = self
+      .hot_keys
+      .len()
+      .saturating_sub(self.hot_tombstones.len());
+    cold_only + hot_active
+  }
 
-    /// Delete all WAL files except the current one
-    fn cleanup_old_wal_files(&self) -> Result<(), PersistError> {
-        let current_segment = self.wal.current_segment();
+  /// Get current logical clock value
+  pub fn get_clock_time(&self) -> u64 {
+    self.hot.get_clock().current_time()
+  }
 
-        if let Ok(entries) = std::fs::read_dir(&self.base_dir) {
-            for entry in entries.flatten() {
-                let filename = entry.file_name();
-                let filename_str = filename.to_string_lossy();
+  /// Delete all WAL files except the current one
+  fn cleanup_old_wal_files(&self) -> Result<(), PersistError> {
+    let current_segment = self.wal.current_segment();
 
-                if filename_str.starts_with("wal_") && filename_str.ends_with(".bin") {
-                    // Parse segment number
-                    if let Some(num_str) = filename_str
-                        .strip_prefix("wal_")
-                        .and_then(|s| s.strip_suffix(".bin"))
-                    {
-                        if let Ok(segment_num) = num_str.parse::<u64>() {
-                            // Keep current segment, delete others
-                            if segment_num < current_segment {
-                                let _ = std::fs::remove_file(entry.path());
-                            }
-                        }
-                    }
-                }
+    if let Ok(entries) = std::fs::read_dir(&self.base_dir) {
+      for entry in entries.flatten() {
+        let filename = entry.file_name();
+        let filename_str = filename.to_string_lossy();
+
+        if filename_str.starts_with("wal_") && filename_str.ends_with(".bin") {
+          // Parse segment number
+          if let Some(num_str) = filename_str
+            .strip_prefix("wal_")
+            .and_then(|s| s.strip_suffix(".bin"))
+          {
+            if let Ok(segment_num) = num_str.parse::<u64>() {
+              // Keep current segment, delete others
+              if segment_num < current_segment {
+                let _ = std::fs::remove_file(entry.path());
+              }
             }
+          }
         }
-
-        Ok(())
+      }
     }
 
-    fn persist_and_notify(&mut self, changes: &[Change<K, C, V>]) -> Result<(), PersistError> {
-        if changes.is_empty() {
-            return Ok(());
-        }
+    Ok(())
+  }
 
-        // Append to WAL
-        self.wal.append(changes)?;
-        self.changes_since_snapshot += changes.len();
-
-        // Add to batch
-        self.batch.extend_from_slice(changes);
-
-        // Auto-flush batch if exceeds max size (prevents OOM)
-        if let Some(max_size) = self.config.persist_config.max_batch_size {
-            if self.batch.len() >= max_size {
-                self.batch.clear();
-            }
-        }
-
-        // Call post hooks
-        for hook in &self.post_hooks {
-            hook.after_op(changes);
-        }
-
-        // Check auto-snapshot
-        self.check_auto_snapshot()?;
-
-        Ok(())
+  fn persist_and_notify(&mut self, changes: &[Change<K, C, V>]) -> Result<(), PersistError> {
+    if changes.is_empty() {
+      return Ok(());
     }
 
-    fn check_auto_snapshot(&mut self) -> Result<(), PersistError> {
-        let should_snapshot = self.changes_since_snapshot
-            >= self.config.persist_config.snapshot_threshold
-            || self
-                .config
-                .persist_config
-                .snapshot_interval_secs
-                .map(|i| self.last_snapshot_time.elapsed().as_secs() >= i)
-                .unwrap_or(false);
+    // Append to WAL
+    self.wal.append(changes)?;
+    self.changes_since_snapshot += changes.len();
 
-        if should_snapshot {
-            self.create_indexed_snapshot()?;
-        }
+    // Add to batch
+    self.batch.extend_from_slice(changes);
 
-        Ok(())
+    // Auto-flush batch if exceeds max size (prevents OOM)
+    if let Some(max_size) = self.config.persist_config.max_batch_size {
+      if self.batch.len() >= max_size {
+        self.batch.clear();
+      }
     }
+
+    // Call post hooks
+    for hook in &self.post_hooks {
+      hook.after_op(changes);
+    }
+
+    // Check auto-snapshot
+    self.check_auto_snapshot()?;
+
+    Ok(())
+  }
+
+  fn check_auto_snapshot(&mut self) -> Result<(), PersistError> {
+    let should_snapshot = self.changes_since_snapshot
+      >= self.config.persist_config.snapshot_threshold
+      || self
+        .config
+        .persist_config
+        .snapshot_interval_secs
+        .map(|i| self.last_snapshot_time.elapsed().as_secs() >= i)
+        .unwrap_or(false);
+
+    if should_snapshot {
+      self.create_indexed_snapshot()?;
+    }
+
+    Ok(())
+  }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use tempfile::TempDir;
+  use super::*;
+  use tempfile::TempDir;
 
-    #[test]
-    fn test_streaming_basic_operations() {
-        let temp_dir = TempDir::new().unwrap();
-        let base_dir = temp_dir.path().to_path_buf();
+  #[test]
+  fn test_streaming_basic_operations() {
+    let temp_dir = TempDir::new().unwrap();
+    let base_dir = temp_dir.path().to_path_buf();
 
-        let mut crdt = StreamingCRDT::<String, String, String>::open(
-            base_dir.clone(),
-            1,
-            StreamingConfig::default(),
+    let mut crdt = StreamingCRDT::<String, String, String>::open(
+      base_dir.clone(),
+      1,
+      StreamingConfig::default(),
+    )
+    .unwrap();
+
+    // Insert
+    let changes = crdt
+      .insert_or_update(
+        &"key1".to_string(),
+        vec![("field1".to_string(), "value1".to_string())],
+      )
+      .unwrap();
+
+    assert_eq!(changes.len(), 1);
+
+    // Get
+    let record = crdt.get_record(&"key1".to_string()).unwrap();
+    assert!(record.is_some());
+    assert_eq!(record.unwrap().fields.get("field1").unwrap(), "value1");
+
+    // Delete
+    let delete = crdt.delete_record(&"key1".to_string()).unwrap();
+    assert!(delete.is_some());
+
+    // Get after delete
+    let record = crdt.get_record(&"key1".to_string()).unwrap();
+    assert!(record.is_none());
+  }
+
+  #[test]
+  fn test_streaming_snapshot_and_reload() {
+    let temp_dir = TempDir::new().unwrap();
+    let base_dir = temp_dir.path().to_path_buf();
+
+    // Create and populate
+    {
+      let mut crdt = StreamingCRDT::<String, String, String>::open(
+        base_dir.clone(),
+        1,
+        StreamingConfig::default(),
+      )
+      .unwrap();
+
+      for i in 0..100 {
+        crdt
+          .insert_or_update(
+            &format!("key{}", i),
+            vec![(format!("field{}", i), format!("value{}", i))],
+          )
+          .unwrap();
+      }
+
+      // Create indexed snapshot
+      crdt.create_indexed_snapshot().unwrap();
+    }
+
+    // Reopen and verify
+    {
+      let mut crdt = StreamingCRDT::<String, String, String>::open(
+        base_dir.clone(),
+        1,
+        StreamingConfig::default(),
+      )
+      .unwrap();
+
+      // Records should be in cold storage
+      assert_eq!(crdt.cold_record_count(), 100);
+      assert_eq!(crdt.hot_record_count(), 0);
+
+      // Access should work (lazy load)
+      let record = crdt.get_record(&"key50".to_string()).unwrap();
+      assert!(record.is_some());
+      assert_eq!(record.unwrap().fields.get("field50").unwrap(), "value50");
+    }
+  }
+
+  #[test]
+  fn test_streaming_hot_cold_merge() {
+    let temp_dir = TempDir::new().unwrap();
+    let base_dir = temp_dir.path().to_path_buf();
+
+    // Create initial data and snapshot
+    {
+      let mut crdt = StreamingCRDT::<String, String, String>::open(
+        base_dir.clone(),
+        1,
+        StreamingConfig::default(),
+      )
+      .unwrap();
+
+      crdt
+        .insert_or_update(
+          &"key1".to_string(),
+          vec![
+            ("field1".to_string(), "cold_value".to_string()),
+            ("field2".to_string(), "unchanged".to_string()),
+          ],
         )
         .unwrap();
 
-        // Insert
-        let changes = crdt
-            .insert_or_update(
-                &"key1".to_string(),
-                vec![("field1".to_string(), "value1".to_string())],
-            )
-            .unwrap();
-
-        assert_eq!(changes.len(), 1);
-
-        // Get
-        let record = crdt.get_record(&"key1".to_string()).unwrap();
-        assert!(record.is_some());
-        assert_eq!(
-            record.unwrap().fields.get("field1").unwrap(),
-            "value1"
-        );
-
-        // Delete
-        let delete = crdt.delete_record(&"key1".to_string()).unwrap();
-        assert!(delete.is_some());
-
-        // Get after delete
-        let record = crdt.get_record(&"key1".to_string()).unwrap();
-        assert!(record.is_none());
+      crdt.create_indexed_snapshot().unwrap();
     }
 
-    #[test]
-    fn test_streaming_snapshot_and_reload() {
-        let temp_dir = TempDir::new().unwrap();
-        let base_dir = temp_dir.path().to_path_buf();
+    // Reopen and modify
+    {
+      let mut crdt = StreamingCRDT::<String, String, String>::open(
+        base_dir.clone(),
+        1,
+        StreamingConfig::default(),
+      )
+      .unwrap();
 
-        // Create and populate
-        {
-            let mut crdt = StreamingCRDT::<String, String, String>::open(
-                base_dir.clone(),
-                1,
-                StreamingConfig::default(),
-            )
-            .unwrap();
+      // Update one field (should load cold record first)
+      crdt
+        .insert_or_update(
+          &"key1".to_string(),
+          vec![("field1".to_string(), "hot_value".to_string())],
+        )
+        .unwrap();
 
-            for i in 0..100 {
-                crdt.insert_or_update(
-                    &format!("key{}", i),
-                    vec![(format!("field{}", i), format!("value{}", i))],
-                )
-                .unwrap();
-            }
+      // Verify merged result
+      let record = crdt.get_record(&"key1".to_string()).unwrap().unwrap();
+      assert_eq!(record.fields.get("field1").unwrap(), "hot_value");
+      assert_eq!(record.fields.get("field2").unwrap(), "unchanged");
+    }
+  }
 
-            // Create indexed snapshot
-            crdt.create_indexed_snapshot().unwrap();
-        }
+  #[test]
+  fn test_get_changes_since_includes_cold() {
+    let temp_dir = TempDir::new().unwrap();
+    let base_dir = temp_dir.path().to_path_buf();
 
-        // Reopen and verify
-        {
-            let mut crdt = StreamingCRDT::<String, String, String>::open(
-                base_dir.clone(),
-                1,
-                StreamingConfig::default(),
-            )
-            .unwrap();
+    // Create data and snapshot
+    {
+      let mut crdt = StreamingCRDT::<String, String, String>::open(
+        base_dir.clone(),
+        1,
+        StreamingConfig::default(),
+      )
+      .unwrap();
 
-            // Records should be in cold storage
-            assert_eq!(crdt.cold_record_count(), 100);
-            assert_eq!(crdt.hot_record_count(), 0);
+      crdt
+        .insert_or_update(
+          &"key1".to_string(),
+          vec![("field1".to_string(), "value1".to_string())],
+        )
+        .unwrap();
 
-            // Access should work (lazy load)
-            let record = crdt.get_record(&"key50".to_string()).unwrap();
-            assert!(record.is_some());
-            assert_eq!(
-                record.unwrap().fields.get("field50").unwrap(),
-                "value50"
-            );
-        }
+      crdt.create_indexed_snapshot().unwrap();
     }
 
-    #[test]
-    fn test_streaming_hot_cold_merge() {
-        let temp_dir = TempDir::new().unwrap();
-        let base_dir = temp_dir.path().to_path_buf();
+    // Reopen and verify get_changes_since includes cold records
+    {
+      let mut crdt = StreamingCRDT::<String, String, String>::open(
+        base_dir.clone(),
+        1,
+        StreamingConfig::default(),
+      )
+      .unwrap();
 
-        // Create initial data and snapshot
-        {
-            let mut crdt = StreamingCRDT::<String, String, String>::open(
-                base_dir.clone(),
-                1,
-                StreamingConfig::default(),
-            )
-            .unwrap();
+      // Should find changes from cold storage when asking for version 0
+      let changes = crdt.get_changes_since(0).unwrap();
+      assert!(!changes.is_empty(), "Should find cold changes");
 
-            crdt.insert_or_update(
-                &"key1".to_string(),
-                vec![
-                    ("field1".to_string(), "cold_value".to_string()),
-                    ("field2".to_string(), "unchanged".to_string()),
-                ],
-            )
-            .unwrap();
+      // Verify the change is for key1
+      assert!(
+        changes.iter().any(|c| c.record_id == "key1"),
+        "Should find change for key1"
+      );
 
-            crdt.create_indexed_snapshot().unwrap();
-        }
+      // Should not find changes after the current clock (future)
+      let current_clock = crdt.get_clock_time();
+      let no_changes = crdt.get_changes_since(current_clock + 100).unwrap();
+      assert!(
+        no_changes.is_empty(),
+        "Should not find changes in the future"
+      );
+    }
+  }
 
-        // Reopen and modify
-        {
-            let mut crdt = StreamingCRDT::<String, String, String>::open(
-                base_dir.clone(),
-                1,
-                StreamingConfig::default(),
-            )
-            .unwrap();
+  #[test]
+  fn test_clock_preserved_across_snapshots() {
+    let temp_dir = TempDir::new().unwrap();
+    let base_dir = temp_dir.path().to_path_buf();
 
-            // Update one field (should load cold record first)
-            crdt.insert_or_update(
-                &"key1".to_string(),
-                vec![("field1".to_string(), "hot_value".to_string())],
-            )
-            .unwrap();
+    let clock_before_snapshot;
+    let clock_after_snapshot;
+    {
+      let mut crdt = StreamingCRDT::<String, String, String>::open(
+        base_dir.clone(),
+        1,
+        StreamingConfig::default(),
+      )
+      .unwrap();
 
-            // Verify merged result
-            let record = crdt.get_record(&"key1".to_string()).unwrap().unwrap();
-            assert_eq!(record.fields.get("field1").unwrap(), "hot_value");
-            assert_eq!(record.fields.get("field2").unwrap(), "unchanged");
-        }
+      for i in 0..10 {
+        crdt
+          .insert_or_update(
+            &format!("key{}", i),
+            vec![("field".to_string(), format!("value{}", i))],
+          )
+          .unwrap();
+      }
+
+      clock_before_snapshot = crdt.get_clock_time();
+      crdt.create_indexed_snapshot().unwrap();
+      clock_after_snapshot = crdt.get_clock_time();
+
+      // Clock should be at least as high after snapshot (merge may advance it)
+      assert!(
+        clock_after_snapshot >= clock_before_snapshot,
+        "Clock should not go backwards"
+      );
     }
 
-    #[test]
-    fn test_get_changes_since_includes_cold() {
-        let temp_dir = TempDir::new().unwrap();
-        let base_dir = temp_dir.path().to_path_buf();
+    // Reopen and verify clock is preserved
+    {
+      let crdt = StreamingCRDT::<String, String, String>::open(
+        base_dir.clone(),
+        1,
+        StreamingConfig::default(),
+      )
+      .unwrap();
 
-        // Create data and snapshot
-        {
-            let mut crdt = StreamingCRDT::<String, String, String>::open(
-                base_dir.clone(),
-                1,
-                StreamingConfig::default(),
-            )
-            .unwrap();
-
-            crdt.insert_or_update(
-                &"key1".to_string(),
-                vec![("field1".to_string(), "value1".to_string())],
-            )
-            .unwrap();
-
-            crdt.create_indexed_snapshot().unwrap();
-        }
-
-        // Reopen and verify get_changes_since includes cold records
-        {
-            let mut crdt = StreamingCRDT::<String, String, String>::open(
-                base_dir.clone(),
-                1,
-                StreamingConfig::default(),
-            )
-            .unwrap();
-
-            // Should find changes from cold storage when asking for version 0
-            let changes = crdt.get_changes_since(0).unwrap();
-            assert!(!changes.is_empty(), "Should find cold changes");
-
-            // Verify the change is for key1
-            assert!(
-                changes.iter().any(|c| c.record_id == "key1"),
-                "Should find change for key1"
-            );
-
-            // Should not find changes after the current clock (future)
-            let current_clock = crdt.get_clock_time();
-            let no_changes = crdt.get_changes_since(current_clock + 100).unwrap();
-            assert!(no_changes.is_empty(), "Should not find changes in the future");
-        }
+      // Clock should match what it was after snapshot
+      assert_eq!(crdt.get_clock_time(), clock_after_snapshot);
     }
+  }
 
-    #[test]
-    fn test_clock_preserved_across_snapshots() {
-        let temp_dir = TempDir::new().unwrap();
-        let base_dir = temp_dir.path().to_path_buf();
+  #[test]
+  fn test_lru_cache_eviction() {
+    let mut cache: LruCache<i32, String> = LruCache::new(3);
 
-        let clock_before_snapshot;
-        let clock_after_snapshot;
-        {
-            let mut crdt = StreamingCRDT::<String, String, String>::open(
-                base_dir.clone(),
-                1,
-                StreamingConfig::default(),
-            )
-            .unwrap();
+    cache.insert(1, "one".to_string());
+    cache.insert(2, "two".to_string());
+    cache.insert(3, "three".to_string());
 
-            for i in 0..10 {
-                crdt.insert_or_update(
-                    &format!("key{}", i),
-                    vec![("field".to_string(), format!("value{}", i))],
-                )
-                .unwrap();
-            }
+    // All should be present
+    assert!(cache.contains_key(&1));
+    assert!(cache.contains_key(&2));
+    assert!(cache.contains_key(&3));
 
-            clock_before_snapshot = crdt.get_clock_time();
-            crdt.create_indexed_snapshot().unwrap();
-            clock_after_snapshot = crdt.get_clock_time();
+    // Access 1 to make it recently used
+    let _ = cache.get(&1);
 
-            // Clock should be at least as high after snapshot (merge may advance it)
-            assert!(
-                clock_after_snapshot >= clock_before_snapshot,
-                "Clock should not go backwards"
-            );
-        }
+    // Insert 4, should evict 2 (oldest)
+    cache.insert(4, "four".to_string());
 
-        // Reopen and verify clock is preserved
-        {
-            let crdt = StreamingCRDT::<String, String, String>::open(
-                base_dir.clone(),
-                1,
-                StreamingConfig::default(),
-            )
-            .unwrap();
-
-            // Clock should match what it was after snapshot
-            assert_eq!(crdt.get_clock_time(), clock_after_snapshot);
-        }
-    }
-
-    #[test]
-    fn test_lru_cache_eviction() {
-        let mut cache: LruCache<i32, String> = LruCache::new(3);
-
-        cache.insert(1, "one".to_string());
-        cache.insert(2, "two".to_string());
-        cache.insert(3, "three".to_string());
-
-        // All should be present
-        assert!(cache.contains_key(&1));
-        assert!(cache.contains_key(&2));
-        assert!(cache.contains_key(&3));
-
-        // Access 1 to make it recently used
-        let _ = cache.get(&1);
-
-        // Insert 4, should evict 2 (oldest)
-        cache.insert(4, "four".to_string());
-
-        assert!(cache.contains_key(&1)); // Still there (was accessed)
-        assert!(!cache.contains_key(&2)); // Evicted
-        assert!(cache.contains_key(&3));
-        assert!(cache.contains_key(&4));
-    }
+    assert!(cache.contains_key(&1)); // Still there (was accessed)
+    assert!(!cache.contains_key(&2)); // Evicted
+    assert!(cache.contains_key(&3));
+    assert!(cache.contains_key(&4));
+  }
 }

--- a/src/persist/streaming.rs
+++ b/src/persist/streaming.rs
@@ -93,6 +93,13 @@ const HEADER_SIZE: usize = std::mem::size_of::<NodeId>() + 5 * std::mem::size_of
 /// Default LRU cache capacity (number of records)
 pub const DEFAULT_CACHE_CAPACITY: usize = 1000;
 
+/// Maximum index section size in bytes (security limit to prevent OOM attacks)
+/// Allows up to ~10 million index entries (at ~100 bytes per entry estimated)
+const MAX_INDEX_SECTION_SIZE: u64 = 1024 * 1024 * 1024; // 1 GB
+
+/// Maximum tombstone section size in bytes (security limit)
+const MAX_TOMBSTONE_SECTION_SIZE: u64 = 256 * 1024 * 1024; // 256 MB
+
 /// Result type for migration function to avoid clippy type_complexity warning
 type MigrationResult<K, C, V> = Result<Option<(ColdStorage<K, C, V>, u64, u64)>, PersistError>;
 
@@ -137,12 +144,23 @@ struct LruCache<K, V> {
   ref_count: HashMap<K, usize>,
 }
 
+/// Initial capacity multiplier for LRU order queue.
+/// Uses 2x capacity because each get() adds a duplicate entry - we need headroom
+/// before compaction kicks in.
+const LRU_ORDER_INITIAL_CAPACITY_MULTIPLIER: usize = 2;
+
+/// Compaction threshold multiplier for LRU order queue.
+/// When order.len() exceeds capacity * this value, we compact to remove stale entries.
+/// Uses 3x because: 2x for normal duplicates + 1x buffer before we need to compact.
+/// Higher values = less frequent compaction but more memory usage.
+const LRU_ORDER_COMPACT_THRESHOLD_MULTIPLIER: usize = 3;
+
 impl<K: Hash + Eq + Clone, V> LruCache<K, V> {
   fn new(capacity: usize) -> Self {
     Self {
       capacity: capacity.max(1), // Ensure at least 1
       map: HashMap::with_capacity(capacity),
-      order: VecDeque::with_capacity(capacity * 2),
+      order: VecDeque::with_capacity(capacity * LRU_ORDER_INITIAL_CAPACITY_MULTIPLIER),
       ref_count: HashMap::with_capacity(capacity),
     }
   }
@@ -173,14 +191,14 @@ impl<K: Hash + Eq + Clone, V> LruCache<K, V> {
     self.map.insert(key, value);
 
     // Compact order queue if it gets too large (prevents unbounded growth)
-    if self.order.len() > self.capacity * 3 {
+    if self.order.len() > self.capacity * LRU_ORDER_COMPACT_THRESHOLD_MULTIPLIER {
       self.compact();
     }
   }
 
   /// Rebuild order queue to remove stale entries
   fn compact(&mut self) {
-    let mut new_order = VecDeque::with_capacity(self.capacity * 2);
+    let mut new_order = VecDeque::with_capacity(self.capacity * LRU_ORDER_INITIAL_CAPACITY_MULTIPLIER);
     let mut new_ref_count: HashMap<K, usize> = HashMap::with_capacity(self.capacity);
 
     // Keep only the most recent entry for each key
@@ -334,6 +352,23 @@ where
       )));
     }
 
+    // Security: Validate section sizes to prevent OOM attacks from malicious snapshots
+    let index_section_size = file_len - index_offset;
+    if index_section_size > MAX_INDEX_SECTION_SIZE {
+      return Err(PersistError::InvalidDirectory(format!(
+        "Index section too large: {} bytes (max {})",
+        index_section_size, MAX_INDEX_SECTION_SIZE
+      )));
+    }
+
+    let tombstone_section_size = index_offset - tombstones_offset;
+    if tombstone_section_size > MAX_TOMBSTONE_SECTION_SIZE {
+      return Err(PersistError::InvalidDirectory(format!(
+        "Tombstone section too large: {} bytes (max {})",
+        tombstone_section_size, MAX_TOMBSTONE_SECTION_SIZE
+      )));
+    }
+
     // Load index from end of file
     reader.seek(SeekFrom::Start(index_offset))?;
     let index_entries: Vec<IndexEntry<K>> =
@@ -471,6 +506,11 @@ where
   batch: Vec<Change<K, C, V>>,
   /// Last snapshot time
   last_snapshot_time: std::time::Instant,
+
+  /// Snapshots that have been successfully uploaded (for safe cleanup)
+  uploaded_snapshots: HashSet<PathBuf>,
+  /// WAL segments that have been successfully uploaded (for safe cleanup)
+  uploaded_wal_segments: HashSet<PathBuf>,
 }
 
 impl<K, C, V> StreamingCRDT<K, C, V>
@@ -534,6 +574,8 @@ where
       wal_segment_hooks: Vec::new(),
       batch: Vec::new(),
       last_snapshot_time: std::time::Instant::now(),
+      uploaded_snapshots: HashSet::new(),
+      uploaded_wal_segments: HashSet::new(),
     };
 
     streaming.replay_wal()?;
@@ -734,15 +776,14 @@ where
     let mut index_entries: Vec<IndexEntry<K>> = Vec::new();
 
     // 1. Stream cold records that are NOT superseded by hot tier
-    //    Filter before collecting to reduce memory usage
-    let cold_keys_to_process: Vec<K> = self
-      .cold
-      .keys()
-      .filter(|k| !self.hot_keys.contains(*k) && !self.hot_tombstones.contains(*k))
-      .cloned()
-      .collect();
+    //    We iterate directly and re-check filters at write time for consistency
+    //    (avoids TOCTOU issues and is clearer about intent)
+    for key in self.cold.keys().cloned().collect::<Vec<_>>() {
+      // Re-check filter at write time (ensures consistency)
+      if self.hot_keys.contains(&key) || self.hot_tombstones.contains(&key) {
+        continue;
+      }
 
-    for key in cold_keys_to_process {
       // Load and write individual record (only one in memory at a time)
       if let Some(record) = self.cold.load_record(&key)? {
         max_clock = max_clock.max(record.highest_local_db_version);
@@ -842,17 +883,17 @@ where
 
     for entry in wal_files {
       let changes: Vec<Change<K, C, V>> = super::wal::read_wal_file(&entry.path())?;
-      let num_changes = changes.len();
       for change in &changes {
-        // Apply to hot tier
+        // Track keys for hot tier membership
         self.hot_keys.insert(change.record_id.clone());
         if change.col_name.is_none() {
           self.hot_tombstones.insert(change.record_id.clone());
         }
       }
-      // Merge the changes
-      self.hot.merge_changes(changes, &DefaultMergeRule);
-      self.changes_since_snapshot += num_changes; // Fix: count actual changes
+      // Merge the changes and count only ACCEPTED changes
+      // (merge_changes may reject some during conflict resolution)
+      let accepted = self.hot.merge_changes(changes, &DefaultMergeRule);
+      self.changes_since_snapshot += accepted.len();
     }
 
     Ok(())
@@ -890,7 +931,14 @@ where
     Ok(None)
   }
 
-  /// Check if a record exists (without loading full record)
+  /// Check if a record exists (without loading full record from disk).
+  ///
+  /// This is a fast membership check that:
+  /// - Returns `false` if the record is tombstoned (deleted)
+  /// - Returns `true` if the key exists in hot tier, cache, or cold storage index
+  ///
+  /// Unlike `get_record()`, this does NOT load the full record from disk,
+  /// making it efficient for existence checks on large datasets.
   pub fn contains_key(&self, key: &K) -> bool {
     if self.hot_tombstones.contains(key) || self.cold.is_tombstoned(key) {
       return false;
@@ -898,7 +946,10 @@ where
     self.hot_keys.contains(key) || self.cache.contains_key(key) || self.cold.contains_key(key)
   }
 
-  /// Check if a record is tombstoned
+  /// Check if a record has been deleted (tombstoned).
+  ///
+  /// Returns `true` if the record was deleted in either hot or cold tier.
+  /// Tombstoned records cannot be updated until compacted.
   pub fn is_tombstoned(&self, key: &K) -> bool {
     self.hot_tombstones.contains(key) || self.cold.is_tombstoned(key)
   }
@@ -939,9 +990,23 @@ where
   }
 
   /// Delete a record
+  ///
+  /// This correctly handles records that exist only in cold storage by loading
+  /// them into the hot tier first before creating the tombstone.
   pub fn delete_record(&mut self, record_id: &K) -> Result<Option<Change<K, C, V>>, PersistError> {
     if self.is_tombstoned(record_id) {
       return Ok(None);
+    }
+
+    // If record exists in cold but not hot, load it first so delete_record works
+    // Without this, deleting a cold-only record would silently fail (no tombstone created)
+    if !self.hot_keys.contains(record_id) && self.cold.contains_key(record_id) {
+      if let Some(cold_record) = self.cold.load_record(record_id)? {
+        self
+          .hot
+          .insert_record_direct(record_id.clone(), cold_record);
+        self.hot_keys.insert(record_id.clone());
+      }
     }
 
     let change = self.hot.delete_record(record_id);
@@ -1087,9 +1152,20 @@ where
     self.hot_tombstones.clear();
     self.cache = LruCache::new(self.config.cache_capacity);
 
-    // Rotate WAL and delete old segments (snapshot has all data)
+    // Rotate WAL (creates new segment, fires hooks on sealed segments)
     let _ = self.wal.rotate(&self.base_dir, &self.wal_segment_hooks)?;
-    self.cleanup_old_wal_files()?;
+
+    // Auto-cleanup old WAL segments that are now captured in the snapshot.
+    // This is necessary for correctness - without it, WAL replay would re-apply
+    // changes that are already in the snapshot, causing hot_keys to be polluted.
+    //
+    // NOTE: If you have async upload hooks, you should:
+    // 1. Disable auto_cleanup_wal by setting auto_cleanup_wal: false in config
+    // 2. Track uploads with mark_wal_segment_uploaded()
+    // 3. Manually call cleanup_old_wal_segments(keep, true) after uploads complete
+    if self.config.persist_config.auto_cleanup_wal.unwrap_or(true) {
+      self.cleanup_old_wal_segments_internal()?;
+    }
 
     // Reset counters
     self.changes_since_snapshot = 0;
@@ -1169,33 +1245,59 @@ where
     Ok(hot_compacted + cold_to_compact)
   }
 
-  /// Add a post-operation hook
+  /// Add a post-operation hook.
+  ///
+  /// The hook is called after each operation is written to WAL (and flushed).
+  /// Use for real-time broadcasting of changes to other nodes.
+  ///
+  /// Note: Hook fires AFTER WAL flush but BEFORE fsync. Changes are in OS
+  /// page cache, safe from process crashes but not power failures.
   pub fn add_post_hook(&mut self, hook: Box<dyn PostOpHook<K, C, V>>) {
     self.post_hooks.push(hook);
   }
 
-  /// Add a snapshot hook
+  /// Add a snapshot hook.
+  ///
+  /// The hook is called after a snapshot has been created and fsynced.
+  /// Use for uploading snapshots to cloud storage (S3, R2, etc.).
+  ///
+  /// The hook receives the snapshot path and the db_version (logical clock value).
   pub fn add_snapshot_hook(&mut self, hook: Box<dyn SnapshotHook>) {
     self.snapshot_hooks.push(hook);
   }
 
-  /// Add a WAL segment hook
+  /// Add a WAL segment hook.
+  ///
+  /// The hook is called when a WAL segment is sealed (rotated).
+  /// Use for archiving WAL segments to cloud storage.
+  ///
+  /// Note: Sealed segments are NOT auto-deleted. Call `cleanup_old_wal_segments()`
+  /// after confirming successful upload.
   pub fn add_wal_segment_hook(&mut self, hook: Box<dyn WalSegmentHook>) {
     self.wal_segment_hooks.push(hook);
   }
 
-  /// Get number of records in hot tier
+  /// Get number of records currently in the hot tier.
+  ///
+  /// The hot tier contains recently modified records that haven't been
+  /// flushed to a snapshot yet. This count includes tombstoned records.
+  ///
+  /// Note: A record may exist in both hot and cold tiers (hot supersedes cold).
   pub fn hot_record_count(&self) -> usize {
     self.hot_keys.len()
   }
 
-  /// Get number of records in cold storage
+  /// Get number of records in cold storage (the indexed snapshot).
+  ///
+  /// This is the number of records persisted in the last snapshot.
+  /// Does not include records added after the snapshot.
   pub fn cold_record_count(&self) -> usize {
     self.cold.len()
   }
 
-  /// Get total number of active records (hot + cold, excluding duplicates and tombstones)
+  /// Get total number of active (non-tombstoned) records.
   ///
+  /// This computes the unique active record count across hot and cold tiers:
   /// Note: Records in hot tier that supersede cold records are counted once.
   /// Tombstoned records are not counted.
   pub fn total_record_count(&self) -> usize {
@@ -1220,8 +1322,138 @@ where
     self.hot.get_clock().current_time()
   }
 
-  /// Delete all WAL files except the current one
-  fn cleanup_old_wal_files(&self) -> Result<(), PersistError> {
+  /// Mark a snapshot as successfully uploaded to cloud storage.
+  ///
+  /// Call this after your snapshot hook has successfully uploaded the file.
+  /// This enables safe cleanup with `cleanup_old_snapshots(keep, true)`.
+  pub fn mark_snapshot_uploaded(&mut self, path: PathBuf) {
+    self.uploaded_snapshots.insert(path);
+  }
+
+  /// Mark a WAL segment as successfully uploaded to cloud storage.
+  ///
+  /// Call this after your WAL segment hook has successfully uploaded the file.
+  /// This enables safe cleanup with `cleanup_old_wal_segments(keep, true)`.
+  pub fn mark_wal_segment_uploaded(&mut self, path: PathBuf) {
+    self.uploaded_wal_segments.insert(path);
+  }
+
+  /// Cleanup old snapshots, keeping the specified number of most recent ones.
+  ///
+  /// # Arguments
+  ///
+  /// * `keep` - Number of most recent snapshots to keep
+  /// * `require_uploaded` - If true, only delete snapshots marked as uploaded via
+  ///   `mark_snapshot_uploaded()`. This prevents data loss if upload hooks fail.
+  ///
+  /// # Returns
+  ///
+  /// Number of snapshots deleted.
+  pub fn cleanup_old_snapshots(
+    &mut self,
+    keep: usize,
+    require_uploaded: bool,
+  ) -> Result<usize, PersistError> {
+    let mut snapshots: Vec<(u64, PathBuf)> = Vec::new();
+
+    if let Ok(entries) = std::fs::read_dir(&self.base_dir) {
+      for entry in entries.flatten() {
+        let filename = entry.file_name();
+        let filename_str = filename.to_string_lossy();
+
+        if filename_str.starts_with("snapshot_indexed_") && filename_str.ends_with(".bin") {
+          if let Some(version_str) = filename_str
+            .strip_prefix("snapshot_indexed_")
+            .and_then(|s| s.strip_suffix(".bin"))
+          {
+            if let Ok(version) = version_str.parse::<u64>() {
+              snapshots.push((version, entry.path()));
+            }
+          }
+        }
+      }
+    }
+
+    // Sort by version (ascending) - oldest first
+    snapshots.sort_by_key(|(v, _)| *v);
+
+    let mut deleted = 0;
+    let delete_count = snapshots.len().saturating_sub(keep);
+
+    for (_, path) in snapshots.into_iter().take(delete_count) {
+      if require_uploaded && !self.uploaded_snapshots.contains(&path) {
+        continue; // Skip - not uploaded yet
+      }
+      if std::fs::remove_file(&path).is_ok() {
+        self.uploaded_snapshots.remove(&path);
+        deleted += 1;
+      }
+    }
+
+    Ok(deleted)
+  }
+
+  /// Cleanup old WAL segments, keeping the specified number of most recent ones.
+  ///
+  /// # Arguments
+  ///
+  /// * `keep` - Number of most recent WAL segments to keep (plus current segment)
+  /// * `require_uploaded` - If true, only delete segments marked as uploaded via
+  ///   `mark_wal_segment_uploaded()`. This prevents data loss if upload hooks fail.
+  ///
+  /// # Returns
+  ///
+  /// Number of WAL segments deleted.
+  pub fn cleanup_old_wal_segments(
+    &mut self,
+    keep: usize,
+    require_uploaded: bool,
+  ) -> Result<usize, PersistError> {
+    let current_segment = self.wal.current_segment();
+    let mut segments: Vec<(u64, PathBuf)> = Vec::new();
+
+    if let Ok(entries) = std::fs::read_dir(&self.base_dir) {
+      for entry in entries.flatten() {
+        let filename = entry.file_name();
+        let filename_str = filename.to_string_lossy();
+
+        if filename_str.starts_with("wal_") && filename_str.ends_with(".bin") {
+          if let Some(num_str) = filename_str
+            .strip_prefix("wal_")
+            .and_then(|s| s.strip_suffix(".bin"))
+          {
+            if let Ok(segment_num) = num_str.parse::<u64>() {
+              // Never delete current segment
+              if segment_num < current_segment {
+                segments.push((segment_num, entry.path()));
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Sort by segment number (ascending) - oldest first
+    segments.sort_by_key(|(n, _)| *n);
+
+    let mut deleted = 0;
+    let delete_count = segments.len().saturating_sub(keep);
+
+    for (_, path) in segments.into_iter().take(delete_count) {
+      if require_uploaded && !self.uploaded_wal_segments.contains(&path) {
+        continue; // Skip - not uploaded yet
+      }
+      if std::fs::remove_file(&path).is_ok() {
+        self.uploaded_wal_segments.remove(&path);
+        deleted += 1;
+      }
+    }
+
+    Ok(deleted)
+  }
+
+  /// Internal WAL cleanup (unconditional, no upload tracking)
+  fn cleanup_old_wal_segments_internal(&self) -> Result<(), PersistError> {
     let current_segment = self.wal.current_segment();
 
     if let Ok(entries) = std::fs::read_dir(&self.base_dir) {
@@ -1230,7 +1462,6 @@ where
         let filename_str = filename.to_string_lossy();
 
         if filename_str.starts_with("wal_") && filename_str.ends_with(".bin") {
-          // Parse segment number
           if let Some(num_str) = filename_str
             .strip_prefix("wal_")
             .and_then(|s| s.strip_suffix(".bin"))
@@ -1254,9 +1485,13 @@ where
       return Ok(());
     }
 
-    // Append to WAL
+    // Append to WAL (includes internal flush)
     self.wal.append(changes)?;
     self.changes_since_snapshot += changes.len();
+
+    // Explicit flush before hooks to guarantee changes are in OS page cache
+    // This ensures hooks (which may broadcast to network) see written data
+    self.wal.flush()?;
 
     // Add to batch
     self.batch.extend_from_slice(changes);
@@ -1268,7 +1503,7 @@ where
       }
     }
 
-    // Call post hooks
+    // Call post hooks (WAL is flushed, safe to broadcast)
     for hook in &self.post_hooks {
       hook.after_op(changes);
     }
@@ -1561,5 +1796,205 @@ mod tests {
     assert!(!cache.contains_key(&2)); // Evicted
     assert!(cache.contains_key(&3));
     assert!(cache.contains_key(&4));
+  }
+
+  /// Test that deleting a record that only exists in cold storage works correctly.
+  /// This was a critical bug where cold-only records couldn't be deleted.
+  #[test]
+  fn test_delete_cold_record() {
+    let temp_dir = TempDir::new().unwrap();
+    let base_dir = temp_dir.path().to_path_buf();
+
+    // Create record and snapshot (moves to cold)
+    {
+      let mut crdt = StreamingCRDT::<String, String, String>::open(
+        base_dir.clone(),
+        1,
+        StreamingConfig::default(),
+      )
+      .unwrap();
+
+      crdt
+        .insert_or_update(
+          &"cold_key".to_string(),
+          vec![("field".to_string(), "value".to_string())],
+        )
+        .unwrap();
+
+      crdt.create_indexed_snapshot().unwrap();
+    }
+
+    // Reopen (record is now cold-only) and delete
+    {
+      let mut crdt = StreamingCRDT::<String, String, String>::open(
+        base_dir.clone(),
+        1,
+        StreamingConfig::default(),
+      )
+      .unwrap();
+
+      // Verify record exists in cold storage
+      assert_eq!(crdt.cold_record_count(), 1);
+      assert_eq!(crdt.hot_record_count(), 0);
+      assert!(crdt.contains_key(&"cold_key".to_string()));
+
+      // Delete the cold-only record
+      let delete_change = crdt.delete_record(&"cold_key".to_string()).unwrap();
+      assert!(
+        delete_change.is_some(),
+        "Delete should return a change for cold-only record"
+      );
+
+      // Verify tombstone exists and record is gone
+      assert!(crdt.is_tombstoned(&"cold_key".to_string()));
+      assert!(!crdt.contains_key(&"cold_key".to_string()));
+      let record = crdt.get_record(&"cold_key".to_string()).unwrap();
+      assert!(record.is_none(), "Deleted record should not be retrievable");
+    }
+
+    // Reopen and verify record doesn't reappear (zombie prevention)
+    {
+      let mut crdt = StreamingCRDT::<String, String, String>::open(
+        base_dir.clone(),
+        1,
+        StreamingConfig::default(),
+      )
+      .unwrap();
+
+      // Record should still be tombstoned after WAL replay
+      assert!(
+        crdt.is_tombstoned(&"cold_key".to_string()),
+        "Tombstone should persist after reopen"
+      );
+      let record = crdt.get_record(&"cold_key".to_string()).unwrap();
+      assert!(
+        record.is_none(),
+        "Deleted record should not reappear after reopen"
+      );
+    }
+  }
+
+  /// Test that clock doesn't jump when loading cold records from remote nodes.
+  /// This was a bug where db_version was used instead of local_db_version.
+  #[test]
+  fn test_clock_causality_on_cold_load() {
+    let temp_dir = TempDir::new().unwrap();
+    let base_dir = temp_dir.path().to_path_buf();
+
+    // Create a CRDT and manually inject a record with high db_version
+    // (simulating a record synced from a node with higher clock)
+    {
+      let mut crdt = StreamingCRDT::<String, String, String>::open(
+        base_dir.clone(),
+        1,
+        StreamingConfig::default(),
+      )
+      .unwrap();
+
+      // Insert a few records to advance local clock
+      for i in 0..5 {
+        crdt
+          .insert_or_update(
+            &format!("key{}", i),
+            vec![("field".to_string(), format!("value{}", i))],
+          )
+          .unwrap();
+      }
+
+      let clock_after_inserts = crdt.get_clock_time();
+      assert!(
+        clock_after_inserts > 0 && clock_after_inserts <= 10,
+        "Clock should be reasonable after 5 inserts"
+      );
+
+      crdt.create_indexed_snapshot().unwrap();
+    }
+
+    // Reopen and update a cold record
+    {
+      let mut crdt = StreamingCRDT::<String, String, String>::open(
+        base_dir.clone(),
+        1,
+        StreamingConfig::default(),
+      )
+      .unwrap();
+
+      let clock_after_reopen = crdt.get_clock_time();
+
+      // Update a cold record (triggers insert_record_direct)
+      crdt
+        .insert_or_update(
+          &"key0".to_string(),
+          vec![("field".to_string(), "updated".to_string())],
+        )
+        .unwrap();
+
+      let clock_after_update = crdt.get_clock_time();
+
+      // Clock should have advanced by a small amount (1-2), not jumped wildly
+      let clock_diff = clock_after_update - clock_after_reopen;
+      assert!(
+        clock_diff <= 5,
+        "Clock should not jump excessively: before={} after={} diff={}",
+        clock_after_reopen,
+        clock_after_update,
+        clock_diff
+      );
+    }
+  }
+
+  /// Test upload tracking and cleanup methods
+  #[test]
+  fn test_upload_tracking_cleanup() {
+    let temp_dir = TempDir::new().unwrap();
+    let base_dir = temp_dir.path().to_path_buf();
+
+    let mut crdt = StreamingCRDT::<String, String, String>::open(
+      base_dir.clone(),
+      1,
+      StreamingConfig::default(),
+    )
+    .unwrap();
+
+    // Create some data and snapshots
+    for i in 0..3 {
+      crdt
+        .insert_or_update(
+          &format!("key{}", i),
+          vec![("field".to_string(), format!("value{}", i))],
+        )
+        .unwrap();
+      crdt.create_indexed_snapshot().unwrap();
+    }
+
+    // Should have 3 snapshots
+    let snapshot_count = std::fs::read_dir(&base_dir)
+      .unwrap()
+      .filter(|e| {
+        e.as_ref()
+          .unwrap()
+          .file_name()
+          .to_string_lossy()
+          .starts_with("snapshot_indexed_")
+      })
+      .count();
+    assert_eq!(snapshot_count, 3);
+
+    // Cleanup without upload tracking (require_uploaded=false)
+    let deleted = crdt.cleanup_old_snapshots(1, false).unwrap();
+    assert_eq!(deleted, 2, "Should delete 2 old snapshots");
+
+    // Only 1 snapshot should remain
+    let remaining = std::fs::read_dir(&base_dir)
+      .unwrap()
+      .filter(|e| {
+        e.as_ref()
+          .unwrap()
+          .file_name()
+          .to_string_lossy()
+          .starts_with("snapshot_indexed_")
+      })
+      .count();
+    assert_eq!(remaining, 1);
   }
 }

--- a/src/persist/streaming.rs
+++ b/src/persist/streaming.rs
@@ -336,8 +336,6 @@ where
 
     let tombstones_offset = u64::from_le_bytes(header_buf[offset..offset + 8].try_into().unwrap());
 
-    let _ = (record_count, tombstone_count); // Silence unused warnings
-
     // Validate offsets
     if index_offset == 0 || index_offset >= file_len {
       return Err(PersistError::InvalidDirectory(format!(
@@ -374,6 +372,15 @@ where
     let index_entries: Vec<IndexEntry<K>> =
       rmp_serde::from_read(&mut reader).map_err(PersistError::MsgpackDecode)?;
 
+    // Validate header record_count against actual index entries
+    if (index_entries.len() as u64) != record_count {
+      return Err(PersistError::InvalidDirectory(format!(
+        "Header record_count ({}) doesn't match actual index entries ({})",
+        record_count,
+        index_entries.len()
+      )));
+    }
+
     let index: HashMap<K, (u64, u32, u64)> = index_entries
       .into_iter()
       .map(|e| (e.key, (e.offset, e.length, e.highest_version)))
@@ -383,6 +390,15 @@ where
     reader.seek(SeekFrom::Start(tombstones_offset))?;
     let tombstone_map: HashMap<K, TombstoneInfo> =
       rmp_serde::from_read(&mut reader).map_err(PersistError::MsgpackDecode)?;
+
+    // Validate header tombstone_count against actual tombstones
+    if (tombstone_map.len() as u64) != tombstone_count {
+      return Err(PersistError::InvalidDirectory(format!(
+        "Header tombstone_count ({}) doesn't match actual tombstones ({})",
+        tombstone_count,
+        tombstone_map.len()
+      )));
+    }
 
     let mut tombstones = TombstoneStorage::new();
     for (key, info) in tombstone_map {
@@ -467,6 +483,28 @@ where
 /// This is designed for datasets too large to fit in memory. Recent changes
 /// are kept in a hot in-memory CRDT, while older data is loaded from an
 /// indexed snapshot file on-demand.
+///
+/// # Thread Safety
+///
+/// **`StreamingCRDT` is NOT thread-safe.** All operations require `&mut self`
+/// (exclusive access) and must be performed from a single thread or protected
+/// by external synchronization (e.g., `Mutex<StreamingCRDT>`).
+///
+/// File operations:
+/// - Files are opened on-demand for each `load_record()` call (no persistent FDs)
+/// - Snapshot files are opened, read, and closed within a single operation
+/// - WAL writes use a single `BufWriter` that is not thread-safe
+///
+/// If you need concurrent access from multiple threads:
+/// 1. Wrap the `StreamingCRDT` in a `Mutex` or `RwLock`
+/// 2. Use separate `StreamingCRDT` instances per thread (not recommended for shared data)
+/// 3. Use a message-passing architecture with a single owner thread
+///
+/// # File Descriptor Usage
+///
+/// Unlike some database designs, `StreamingCRDT` does NOT keep snapshot files open.
+/// Files are opened on-demand for each cold record load and closed immediately.
+/// This prevents FD exhaustion when running many `StreamingCRDT` instances.
 pub struct StreamingCRDT<K, C, V>
 where
   K: Ord + Hash + Eq + Clone,
@@ -658,14 +696,23 @@ where
       bytes
     };
 
-    // Parse header
+    // Parse header with detailed error messages
     if bytes.len() < 4 {
-      return Ok(None);
+      return Err(PersistError::InvalidDirectory(format!(
+        "Snapshot file too small to contain header: {} bytes (path: {})",
+        bytes.len(),
+        path.display()
+      )));
     }
 
     let metadata_len = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
     if bytes.len() < 4 + metadata_len {
-      return Ok(None);
+      return Err(PersistError::InvalidDirectory(format!(
+        "Snapshot truncated: header says {} bytes metadata but file only has {} bytes after header (path: {})",
+        metadata_len,
+        bytes.len().saturating_sub(4),
+        path.display()
+      )));
     }
 
     let crdt_bytes = &bytes[4 + metadata_len..];
@@ -707,8 +754,17 @@ where
 
     // Write records and build index
     let mut index_entries: Vec<IndexEntry<K>> = Vec::new();
+    let clock_time = crdt.get_clock().current_time();
 
     for (key, record) in crdt.get_data().iter() {
+      // Clock consistency: record versions should not exceed CRDT clock
+      debug_assert!(
+        record.highest_local_db_version <= clock_time,
+        "Record has version {} but CRDT clock is {} - clock inconsistency",
+        record.highest_local_db_version,
+        clock_time
+      );
+
       let offset = file.stream_position()?;
       let record_bytes = rmp_serde::to_vec(record).map_err(PersistError::MsgpackEncode)?;
       file.write_all(&record_bytes)?;
@@ -786,10 +842,27 @@ where
 
       // Load and write individual record (only one in memory at a time)
       if let Some(record) = self.cold.load_record(&key)? {
+        // Clock consistency: record versions should not exceed our clock
+        debug_assert!(
+          record.highest_local_db_version <= max_clock,
+          "Cold record has version {} but max_clock is {} - clock inconsistency",
+          record.highest_local_db_version,
+          max_clock
+        );
         max_clock = max_clock.max(record.highest_local_db_version);
 
         let offset = file.stream_position()?;
         let record_bytes = rmp_serde::to_vec(&record).map_err(PersistError::MsgpackEncode)?;
+
+        // Validate record size fits in u32 (index uses u32 for length)
+        if record_bytes.len() > u32::MAX as usize {
+          return Err(PersistError::InvalidDirectory(format!(
+            "Record too large: {} bytes (max {} bytes)",
+            record_bytes.len(),
+            u32::MAX
+          )));
+        }
+
         file.write_all(&record_bytes)?;
 
         index_entries.push(IndexEntry {
@@ -803,10 +876,27 @@ where
 
     // 2. Write hot tier records (already in memory, no extra load)
     for (key, record) in self.hot.get_data().iter() {
+      // Clock consistency: hot record versions should not exceed our clock
+      debug_assert!(
+        record.highest_local_db_version <= max_clock,
+        "Hot record has version {} but max_clock is {} - clock inconsistency",
+        record.highest_local_db_version,
+        max_clock
+      );
       max_clock = max_clock.max(record.highest_local_db_version);
 
       let offset = file.stream_position()?;
       let record_bytes = rmp_serde::to_vec(record).map_err(PersistError::MsgpackEncode)?;
+
+      // Validate record size fits in u32 (index uses u32 for length)
+      if record_bytes.len() > u32::MAX as usize {
+        return Err(PersistError::InvalidDirectory(format!(
+          "Record too large: {} bytes (max {} bytes)",
+          record_bytes.len(),
+          u32::MAX
+        )));
+      }
+
       file.write_all(&record_bytes)?;
 
       index_entries.push(IndexEntry {

--- a/src/persist/streaming.rs
+++ b/src/persist/streaming.rs
@@ -183,10 +183,11 @@ impl<K: Hash + Eq + Clone, V> LruCache<K, V> {
       while self.map.len() >= self.capacity {
         self.evict_one();
       }
-      // Only update order for new keys
-      self.order.push_back(key.clone());
-      *self.ref_count.entry(key.clone()).or_insert(0) += 1;
     }
+    // Always mark as recently used (both new and updated keys)
+    // Without this, frequently updated keys get evicted despite being "hot"
+    self.order.push_back(key.clone());
+    *self.ref_count.entry(key.clone()).or_insert(0) += 1;
     // Always update the value
     self.map.insert(key, value);
 
@@ -198,7 +199,8 @@ impl<K: Hash + Eq + Clone, V> LruCache<K, V> {
 
   /// Rebuild order queue to remove stale entries
   fn compact(&mut self) {
-    let mut new_order = VecDeque::with_capacity(self.capacity * LRU_ORDER_INITIAL_CAPACITY_MULTIPLIER);
+    let mut new_order =
+      VecDeque::with_capacity(self.capacity * LRU_ORDER_INITIAL_CAPACITY_MULTIPLIER);
     let mut new_ref_count: HashMap<K, usize> = HashMap::with_capacity(self.capacity);
 
     // Keep only the most recent entry for each key
@@ -237,13 +239,6 @@ impl<K: Hash + Eq + Clone, V> LruCache<K, V> {
 
   fn contains_key(&self, key: &K) -> bool {
     self.map.contains_key(key)
-  }
-
-  #[allow(dead_code)]
-  fn clear(&mut self) {
-    self.map.clear();
-    self.order.clear();
-    self.ref_count.clear();
   }
 }
 
@@ -450,12 +445,6 @@ where
   /// Check if a record is tombstoned
   fn is_tombstoned(&self, key: &K) -> bool {
     self.tombstones.find(key).is_some()
-  }
-
-  /// Get tombstone info
-  #[allow(dead_code)]
-  fn get_tombstone(&self, key: &K) -> Option<TombstoneInfo> {
-    self.tombstones.find(key)
   }
 
   /// Iterate over keys (without collecting into Vec to save memory)
@@ -1113,9 +1102,14 @@ where
     &mut self,
     changes: Vec<Change<K, C, V>>,
   ) -> Result<Vec<Change<K, C, V>>, PersistError> {
-    // Load any cold records that are being updated
+    // Load any cold records that are being updated (skip tombstoned records
+    // to prevent zombie resurrection — a field update for a deleted record
+    // must not bring it back to life)
     for change in &changes {
-      if !self.hot_keys.contains(&change.record_id) && self.cold.contains_key(&change.record_id) {
+      if !self.hot_keys.contains(&change.record_id)
+        && !self.is_tombstoned(&change.record_id)
+        && self.cold.contains_key(&change.record_id)
+      {
         if let Some(cold_record) = self.cold.load_record(&change.record_id)? {
           // Directly insert cold record into hot storage (preserves version metadata)
           self
@@ -1249,11 +1243,15 @@ where
     // This is necessary for correctness - without it, WAL replay would re-apply
     // changes that are already in the snapshot, causing hot_keys to be polluted.
     //
-    // NOTE: If you have async upload hooks, you should:
-    // 1. Disable auto_cleanup_wal by setting auto_cleanup_wal: false in config
-    // 2. Track uploads with mark_wal_segment_uploaded()
-    // 3. Manually call cleanup_old_wal_segments(keep, true) after uploads complete
-    if self.config.persist_config.auto_cleanup_wal.unwrap_or(true) {
+    // When WAL segment hooks are registered, auto-cleanup is disabled by default
+    // to prevent deleting WAL files before async upload hooks complete.
+    // Override with auto_cleanup_wal: Some(true/false) in config.
+    let auto_cleanup = self
+      .config
+      .persist_config
+      .auto_cleanup_wal
+      .unwrap_or(self.wal_segment_hooks.is_empty());
+    if auto_cleanup {
       self.cleanup_old_wal_segments_internal()?;
     }
 
@@ -1280,12 +1278,13 @@ where
   /// **CRITICAL**: Only call this after ALL nodes have acknowledged the version.
   /// Premature compaction can cause deleted records to reappear (zombie records).
   ///
-  /// This creates a new snapshot with compacted tombstones, then reloads cold storage.
+  /// This compacts tombstones in both hot and cold tiers, creates a new snapshot
+  /// capturing the compacted state, and unconditionally deletes old WAL segments.
   ///
   /// # Arguments
   ///
   /// * `min_acknowledged_version` - The minimum version acknowledged by all nodes.
-  ///   Tombstones with `local_db_version <= min_acknowledged_version` will be removed.
+  ///   Tombstones with `db_version < min_acknowledged_version` will be removed.
   ///
   /// # Returns
   ///
@@ -1297,42 +1296,40 @@ where
     // Compact hot tier tombstones
     let hot_compacted = self.hot.compact_tombstones(min_acknowledged_version);
 
-    // Remove from hot_tombstones tracking set for compacted tombstones
+    // Remove from hot_tombstones AND hot_keys tracking sets for compacted tombstones.
+    // Removing from hot_keys is critical: if a key stays in hot_keys after its hot
+    // tombstone is compacted, create_streaming_snapshot will skip the cold tombstone
+    // for that key (assuming hot supersedes it), causing the tombstone to vanish
+    // entirely from the snapshot — leading to zombie record resurrection.
     let keys_to_remove: Vec<K> = self
       .hot_tombstones
       .iter()
-      .filter(|k| {
-        if self.hot.get_tombstones().find(*k).is_some() {
-          false // Still exists, don't remove from tracking
-        } else {
-          true // Was compacted, remove from tracking
-        }
-      })
+      .filter(|k| self.hot.get_tombstones().find(*k).is_none())
       .cloned()
       .collect();
 
-    for key in keys_to_remove {
-      self.hot_tombstones.remove(&key);
+    for key in &keys_to_remove {
+      self.hot_tombstones.remove(key);
+      self.hot_keys.remove(key);
     }
 
-    // Count cold tombstones that will be compacted
-    let cold_to_compact: usize = self
-      .cold
-      .tombstones
-      .iter()
-      .filter(|(_, info)| info.local_db_version <= min_acknowledged_version)
-      .count();
+    // Compact cold tombstones in-memory BEFORE creating snapshot,
+    // so the snapshot captures the compacted state.
+    let cold_compacted = self.cold.tombstones.compact(min_acknowledged_version);
 
-    // If there are cold tombstones to compact, create new snapshot
-    if cold_to_compact > 0 {
-      // Force snapshot which will merge tombstones and apply compaction
+    let total = hot_compacted + cold_compacted;
+    if total > 0 {
+      // Force snapshot to persist the compacted state
       self.create_indexed_snapshot()?;
 
-      // Now compact the reloaded cold storage tombstones
-      self.cold.tombstones.compact(min_acknowledged_version);
+      // CRITICAL: Delete old WAL segments that contain tombstone records.
+      // Failure to do this causes zombie records to reappear on recovery.
+      // This must be unconditional regardless of auto_cleanup_wal config,
+      // matching PersistedCRDT::compact_tombstones behavior.
+      self.cleanup_old_wal_segments(0, false)?;
     }
 
-    Ok(hot_compacted + cold_to_compact)
+    Ok(total)
   }
 
   /// Add a post-operation hook.
@@ -1410,6 +1407,76 @@ where
   /// Get current logical clock value
   pub fn get_clock_time(&self) -> u64 {
     self.hot.get_clock().current_time()
+  }
+
+  /// Returns the node ID of this CRDT instance.
+  pub fn node_id(&self) -> NodeId {
+    self.hot.node_id()
+  }
+
+  /// Explicitly create a snapshot of the current state.
+  ///
+  /// This is an alias for `create_indexed_snapshot()` that matches the
+  /// `PersistedCRDT::snapshot()` API for consistency.
+  pub fn snapshot(&mut self) -> Result<PathBuf, PersistError> {
+    self.create_indexed_snapshot()
+  }
+
+  /// Get the current number of changes since the last snapshot.
+  pub fn changes_since_snapshot(&self) -> usize {
+    self.changes_since_snapshot
+  }
+
+  /// Peek at the current batch without consuming it.
+  pub fn peek_batch(&self) -> &[Change<K, C, V>] {
+    &self.batch
+  }
+
+  /// Delete a specific field from a record.
+  ///
+  /// If the record only exists in cold storage, it is loaded into the hot
+  /// tier first. Returns `None` if the record or field doesn't exist, or
+  /// if the record is tombstoned.
+  pub fn delete_field(
+    &mut self,
+    record_id: &K,
+    field_name: &C,
+  ) -> Result<Option<Change<K, C, V>>, PersistError> {
+    if self.is_tombstoned(record_id) {
+      return Ok(None);
+    }
+
+    // Load cold record into hot if needed
+    if !self.hot_keys.contains(record_id) && self.cold.contains_key(record_id) {
+      if let Some(cold_record) = self.cold.load_record(record_id)? {
+        self
+          .hot
+          .insert_record_direct(record_id.clone(), cold_record);
+        self.hot_keys.insert(record_id.clone());
+      }
+    }
+
+    let change = self.hot.delete_field(record_id, field_name);
+    if let Some(ref c) = change {
+      self.hot_keys.insert(record_id.clone());
+      self.persist_and_notify(std::slice::from_ref(c))?;
+    }
+
+    Ok(change)
+  }
+
+  /// Get changes since a version, excluding changes from specific nodes.
+  ///
+  /// Useful for syncing with peers — exclude the peer's own node ID to avoid
+  /// echoing their changes back to them.
+  pub fn get_changes_since_excluding(
+    &mut self,
+    last_db_version: u64,
+    excluding: &HashSet<NodeId>,
+  ) -> Result<Vec<Change<K, C, V>>, PersistError> {
+    let mut changes = self.get_changes_since(last_db_version)?;
+    changes.retain(|c| !excluding.contains(&c.node_id));
+    Ok(changes)
   }
 
   /// Mark a snapshot as successfully uploaded to cloud storage.
@@ -1546,21 +1613,20 @@ where
   fn cleanup_old_wal_segments_internal(&self) -> Result<(), PersistError> {
     let current_segment = self.wal.current_segment();
 
-    if let Ok(entries) = std::fs::read_dir(&self.base_dir) {
-      for entry in entries.flatten() {
-        let filename = entry.file_name();
-        let filename_str = filename.to_string_lossy();
+    let entries = std::fs::read_dir(&self.base_dir)?;
+    for entry in entries.flatten() {
+      let filename = entry.file_name();
+      let filename_str = filename.to_string_lossy();
 
-        if filename_str.starts_with("wal_") && filename_str.ends_with(".bin") {
-          if let Some(num_str) = filename_str
-            .strip_prefix("wal_")
-            .and_then(|s| s.strip_suffix(".bin"))
-          {
-            if let Ok(segment_num) = num_str.parse::<u64>() {
-              // Keep current segment, delete others
-              if segment_num < current_segment {
-                let _ = std::fs::remove_file(entry.path());
-              }
+      if filename_str.starts_with("wal_") && filename_str.ends_with(".bin") {
+        if let Some(num_str) = filename_str
+          .strip_prefix("wal_")
+          .and_then(|s| s.strip_suffix(".bin"))
+        {
+          if let Ok(segment_num) = num_str.parse::<u64>() {
+            // Keep current segment, delete others
+            if segment_num < current_segment {
+              std::fs::remove_file(entry.path())?;
             }
           }
         }
@@ -1587,9 +1653,11 @@ where
     self.batch.extend_from_slice(changes);
 
     // Auto-flush batch if exceeds max size (prevents OOM)
+    // Keeps only the most recent half to preserve some data for late consumers
     if let Some(max_size) = self.config.persist_config.max_batch_size {
       if self.batch.len() >= max_size {
-        self.batch.clear();
+        let keep_from = self.batch.len() / 2;
+        self.batch.drain(..keep_from);
       }
     }
 
@@ -2086,5 +2154,226 @@ mod tests {
       })
       .count();
     assert_eq!(remaining, 1);
+  }
+
+  /// Test that LRU cache correctly handles updates to existing keys.
+  /// Previously, updating an existing key didn't mark it as recently used,
+  /// causing frequently-updated records to be evicted.
+  #[test]
+  fn test_lru_cache_update_marks_recent() {
+    let mut cache: LruCache<i32, String> = LruCache::new(3);
+
+    cache.insert(1, "one".to_string());
+    cache.insert(2, "two".to_string());
+    cache.insert(3, "three".to_string());
+
+    // Update key 1 (should mark it as recently used)
+    cache.insert(1, "one_updated".to_string());
+
+    // Insert 4 — should evict 2 (oldest untouched), not 1 (recently updated)
+    cache.insert(4, "four".to_string());
+
+    assert!(cache.contains_key(&1), "Updated key should not be evicted");
+    assert_eq!(cache.get(&1).unwrap(), "one_updated");
+    assert!(
+      !cache.contains_key(&2),
+      "Oldest untouched key should be evicted"
+    );
+    assert!(cache.contains_key(&3));
+    assert!(cache.contains_key(&4));
+  }
+
+  /// Test that merge_changes does not resurrect tombstoned cold records.
+  #[test]
+  fn test_merge_changes_no_zombie_resurrection() {
+    let temp_dir = TempDir::new().unwrap();
+    let base_dir = temp_dir.path().to_path_buf();
+
+    // Create a record, snapshot it (goes cold), then delete it
+    {
+      let mut crdt = StreamingCRDT::<String, String, String>::open(
+        base_dir.clone(),
+        1,
+        StreamingConfig::default(),
+      )
+      .unwrap();
+
+      crdt
+        .insert_or_update(
+          &"victim".to_string(),
+          vec![("field".to_string(), "value".to_string())],
+        )
+        .unwrap();
+
+      crdt.create_indexed_snapshot().unwrap();
+    }
+
+    // Reopen: record is cold. Delete it, then try to merge a field update for it.
+    {
+      let mut crdt = StreamingCRDT::<String, String, String>::open(
+        base_dir.clone(),
+        1,
+        StreamingConfig::default(),
+      )
+      .unwrap();
+
+      // Delete the cold record
+      crdt.delete_record(&"victim".to_string()).unwrap();
+      assert!(crdt.is_tombstoned(&"victim".to_string()));
+
+      // Simulate a remote node sending a field update for the deleted record
+      let remote_change = Change::new(
+        "victim".to_string(),
+        Some("field".to_string()),
+        Some("resurrected".to_string()),
+        1,  // col_version
+        50, // db_version (high, from remote)
+        99, // node_id (different node)
+        50, // local_db_version
+        0,
+      );
+
+      let accepted = crdt.merge_changes(vec![remote_change]).unwrap();
+      // The change may or may not be accepted by the merge rule,
+      // but the record should remain tombstoned
+      let _ = accepted;
+
+      // Record must still be gone
+      let record = crdt.get_record(&"victim".to_string()).unwrap();
+      assert!(
+        record.is_none(),
+        "Tombstoned record should not be resurrected by merge"
+      );
+    }
+  }
+
+  /// Test delete_field on cold records
+  #[test]
+  fn test_delete_field_cold_record() {
+    let temp_dir = TempDir::new().unwrap();
+    let base_dir = temp_dir.path().to_path_buf();
+
+    // Create record with two fields and snapshot
+    {
+      let mut crdt = StreamingCRDT::<String, String, String>::open(
+        base_dir.clone(),
+        1,
+        StreamingConfig::default(),
+      )
+      .unwrap();
+
+      crdt
+        .insert_or_update(
+          &"key1".to_string(),
+          vec![
+            ("name".to_string(), "Alice".to_string()),
+            ("email".to_string(), "alice@example.com".to_string()),
+          ],
+        )
+        .unwrap();
+
+      crdt.create_indexed_snapshot().unwrap();
+    }
+
+    // Reopen and delete one field
+    {
+      let mut crdt = StreamingCRDT::<String, String, String>::open(
+        base_dir.clone(),
+        1,
+        StreamingConfig::default(),
+      )
+      .unwrap();
+
+      assert_eq!(crdt.hot_record_count(), 0);
+
+      let change = crdt
+        .delete_field(&"key1".to_string(), &"email".to_string())
+        .unwrap();
+      assert!(
+        change.is_some(),
+        "Should return a change for field deletion"
+      );
+
+      // Record should still exist with remaining field
+      let record = crdt.get_record(&"key1".to_string()).unwrap().unwrap();
+      assert_eq!(record.fields.get("name").unwrap(), "Alice");
+      assert!(
+        record.fields.get("email").is_none(),
+        "Deleted field should be gone"
+      );
+    }
+  }
+
+  /// Test node_id(), snapshot() alias, changes_since_snapshot(), peek_batch()
+  #[test]
+  fn test_api_parity_methods() {
+    let temp_dir = TempDir::new().unwrap();
+    let base_dir = temp_dir.path().to_path_buf();
+
+    let mut crdt = StreamingCRDT::<String, String, String>::open(
+      base_dir.clone(),
+      42,
+      StreamingConfig::default(),
+    )
+    .unwrap();
+
+    assert_eq!(crdt.node_id(), 42);
+    assert_eq!(crdt.changes_since_snapshot(), 0);
+    assert!(crdt.peek_batch().is_empty());
+
+    crdt
+      .insert_or_update(
+        &"key1".to_string(),
+        vec![("f".to_string(), "v".to_string())],
+      )
+      .unwrap();
+
+    assert_eq!(crdt.changes_since_snapshot(), 1);
+    assert_eq!(crdt.peek_batch().len(), 1);
+
+    // take_batch clears it
+    let batch = crdt.take_batch();
+    assert_eq!(batch.len(), 1);
+    assert!(crdt.peek_batch().is_empty());
+
+    // snapshot() alias works
+    let path = crdt.snapshot().unwrap();
+    assert!(path.exists());
+    assert_eq!(crdt.changes_since_snapshot(), 0);
+  }
+
+  /// Test get_changes_since_excluding
+  #[test]
+  fn test_get_changes_since_excluding() {
+    let temp_dir = TempDir::new().unwrap();
+    let base_dir = temp_dir.path().to_path_buf();
+
+    let mut crdt = StreamingCRDT::<String, String, String>::open(
+      base_dir.clone(),
+      1,
+      StreamingConfig::default(),
+    )
+    .unwrap();
+
+    crdt
+      .insert_or_update(
+        &"key1".to_string(),
+        vec![("f".to_string(), "v".to_string())],
+      )
+      .unwrap();
+
+    // Should find changes from node 1
+    let all = crdt.get_changes_since(0).unwrap();
+    assert!(!all.is_empty());
+
+    // Excluding node 1 should return nothing
+    let excluding = HashSet::from([1u64]);
+    let filtered = crdt.get_changes_since_excluding(0, &excluding).unwrap();
+    assert!(filtered.is_empty(), "Should exclude node 1's changes");
+
+    // Excluding a different node should return all changes
+    let other = HashSet::from([99u64]);
+    let not_filtered = crdt.get_changes_since_excluding(0, &other).unwrap();
+    assert_eq!(not_filtered.len(), all.len());
   }
 }

--- a/src/persist/streaming.rs
+++ b/src/persist/streaming.rs
@@ -121,6 +121,9 @@ struct IndexEntry<K> {
     key: K,
     offset: u64,
     length: u32,
+    /// Highest local_db_version in this record (for efficient sync queries)
+    #[cfg_attr(feature = "serde", serde(default))]
+    highest_version: u64,
 }
 
 /// O(1) LRU cache implementation using HashMap + VecDeque with reference counting
@@ -156,15 +159,40 @@ impl<K: Hash + Eq + Clone, V> LruCache<K, V> {
     }
 
     fn insert(&mut self, key: K, value: V) {
-        if !self.map.contains_key(&key) {
+        let is_new = !self.map.contains_key(&key);
+        if is_new {
             // Evict if at capacity
             while self.map.len() >= self.capacity {
                 self.evict_one();
             }
+            // Only update order for new keys
+            self.order.push_back(key.clone());
+            *self.ref_count.entry(key.clone()).or_insert(0) += 1;
         }
-        self.order.push_back(key.clone());
-        *self.ref_count.entry(key.clone()).or_insert(0) += 1;
+        // Always update the value
         self.map.insert(key, value);
+
+        // Compact order queue if it gets too large (prevents unbounded growth)
+        if self.order.len() > self.capacity * 10 {
+            self.compact();
+        }
+    }
+
+    /// Rebuild order queue to remove stale entries
+    fn compact(&mut self) {
+        let mut new_order = VecDeque::with_capacity(self.capacity * 2);
+        let mut new_ref_count: HashMap<K, usize> = HashMap::with_capacity(self.capacity);
+
+        // Keep only the most recent entry for each key
+        for key in self.order.drain(..).rev() {
+            if self.map.contains_key(&key) && !new_ref_count.contains_key(&key) {
+                new_ref_count.insert(key.clone(), 1);
+                new_order.push_front(key);
+            }
+        }
+
+        self.order = new_order;
+        self.ref_count = new_ref_count;
     }
 
     fn evict_one(&mut self) {
@@ -210,8 +238,9 @@ where
 {
     /// The snapshot file (kept open for seeking)
     file: Option<BufReader<File>>,
-    /// Key -> (offset, length) index
-    index: HashMap<K, (u64, u32)>,
+    /// Key -> (offset, length, highest_local_db_version) index
+    /// The version is used for efficient get_changes_since queries
+    index: HashMap<K, (u64, u32, u64)>,
     /// Tombstones (loaded entirely at startup)
     tombstones: TombstoneStorage<K>,
     /// Clock value from snapshot
@@ -303,9 +332,9 @@ where
         let index_entries: Vec<IndexEntry<K>> = rmp_serde::from_read(&mut reader)
             .map_err(PersistError::MsgpackDecode)?;
 
-        let index: HashMap<K, (u64, u32)> = index_entries
+        let index: HashMap<K, (u64, u32, u64)> = index_entries
             .into_iter()
-            .map(|e| (e.key, (e.offset, e.length)))
+            .map(|e| (e.key, (e.offset, e.length, e.highest_version)))
             .collect();
 
         // Load tombstones
@@ -332,8 +361,8 @@ where
 
     /// Load a single record from disk
     fn load_record(&mut self, key: &K) -> Result<Option<Record<C, V>>, PersistError> {
-        let (offset, length) = match self.index.get(key) {
-            Some(&(o, l)) => (o, l),
+        let (offset, length, _version) = match self.index.get(key) {
+            Some(&(o, l, v)) => (o, l, v),
             None => return Ok(None),
         };
 
@@ -364,6 +393,7 @@ where
     }
 
     /// Get tombstone info
+    #[allow(dead_code)]
     fn get_tombstone(&self, key: &K) -> Option<TombstoneInfo> {
         self.tombstones.find(key)
     }
@@ -371,6 +401,14 @@ where
     /// Iterate over keys (without collecting into Vec to save memory)
     fn keys(&self) -> impl Iterator<Item = &K> {
         self.index.keys()
+    }
+
+    /// Get keys with changes after a specific version (for efficient sync)
+    fn keys_with_changes_since(&self, last_db_version: u64) -> impl Iterator<Item = &K> {
+        self.index
+            .iter()
+            .filter(move |(_, (_, _, highest_version))| *highest_version > last_db_version)
+            .map(|(k, _)| k)
     }
 
     /// Get number of records in cold storage
@@ -635,6 +673,7 @@ where
                 key: key.clone(),
                 offset,
                 length: record_bytes.len() as u32,
+                highest_version: record.highest_local_db_version,
             });
         }
 
@@ -841,40 +880,43 @@ where
     /// Get changes since a version (for sync)
     ///
     /// This scans both hot and cold storage to ensure all changes are included.
+    ///
+    /// # Performance
+    ///
+    /// Uses an indexed lookup to find cold records with changes after `last_db_version`,
+    /// avoiding a full scan of all records. Only records that actually have changes
+    /// after the specified version are loaded from disk.
+    ///
+    /// For optimal performance, call `get_changes_since` with the highest version
+    /// you've already synced to minimize the number of records loaded.
     pub fn get_changes_since(&mut self, last_db_version: u64) -> Result<Vec<Change<K, C, V>>, PersistError> {
         // Hot tier changes
         let mut changes = self.hot.get_changes_since(last_db_version);
 
-        // Scan cold storage for records with changes after last_db_version
-        // This is necessary to ensure sync completeness
-        for key in self.cold.keys().cloned().collect::<Vec<_>>() {
-            // Skip if already in hot (hot has newer data)
-            if self.hot_keys.contains(&key) {
-                continue;
-            }
-            // Skip if tombstoned
-            if self.hot_tombstones.contains(&key) {
-                continue;
-            }
+        // Use indexed lookup for cold records with changes after last_db_version
+        // This avoids scanning ALL cold records - only those with matching versions
+        let cold_keys_to_check: Vec<K> = self.cold
+            .keys_with_changes_since(last_db_version)
+            .filter(|k| !self.hot_keys.contains(*k) && !self.hot_tombstones.contains(*k))
+            .cloned()
+            .collect();
 
+        for key in cold_keys_to_check {
             if let Some(record) = self.cold.load_record(&key)? {
-                // Check if record has changes after last_db_version
-                if record.highest_local_db_version > last_db_version {
-                    // Convert record to changes
-                    for (col_name, value) in &record.fields {
-                        if let Some(col_ver) = record.column_versions.get(col_name) {
-                            if col_ver.local_db_version > last_db_version {
-                                changes.push(Change::new(
-                                    key.clone(),
-                                    Some(col_name.clone()),
-                                    Some(value.clone()),
-                                    col_ver.col_version,
-                                    col_ver.db_version,
-                                    col_ver.node_id,
-                                    col_ver.local_db_version,
-                                    0,
-                                ));
-                            }
+                // Convert record to changes
+                for (col_name, value) in &record.fields {
+                    if let Some(col_ver) = record.column_versions.get(col_name) {
+                        if col_ver.local_db_version > last_db_version {
+                            changes.push(Change::new(
+                                key.clone(),
+                                Some(col_name.clone()),
+                                Some(value.clone()),
+                                col_ver.col_version,
+                                col_ver.db_version,
+                                col_ver.node_id,
+                                col_ver.local_db_version,
+                                0,
+                            ));
                         }
                     }
                 }
@@ -1020,6 +1062,17 @@ where
         self.cold.len()
     }
 
+    /// Get total number of records (hot + cold, excluding duplicates)
+    ///
+    /// Note: Records in hot tier that supersede cold records are counted once.
+    pub fn total_record_count(&self) -> usize {
+        // Cold records not in hot + hot records
+        let cold_only = self.cold.index.keys()
+            .filter(|k| !self.hot_keys.contains(*k) && !self.hot_tombstones.contains(*k))
+            .count();
+        cold_only + self.hot_keys.len()
+    }
+
     /// Get current logical clock value
     pub fn get_clock_time(&self) -> u64 {
         self.hot.get_clock().current_time()
@@ -1065,6 +1118,13 @@ where
 
         // Add to batch
         self.batch.extend_from_slice(changes);
+
+        // Auto-flush batch if exceeds max size (prevents OOM)
+        if let Some(max_size) = self.config.persist_config.max_batch_size {
+            if self.batch.len() >= max_size {
+                self.batch.clear();
+            }
+        }
 
         // Call post hooks
         for hook in &self.post_hooks {
@@ -1112,10 +1172,16 @@ impl<K: Ord + Hash + Eq + Clone, C: Hash + Eq + Clone, V: Clone> CRDT<K, C, V> {
     /// when loading cold records into hot storage.
     pub(crate) fn insert_record_direct(&mut self, key: K, record: Record<C, V>) {
         // Update clock to at least match the record's versions
-        for col_ver in record.column_versions.values() {
-            if col_ver.db_version > self.clock.current_time() {
-                self.clock.set_time(col_ver.db_version);
-            }
+        // Check both column versions and highest_local_db_version to handle all cases
+        let max_version = record.column_versions
+            .values()
+            .map(|v| v.db_version)
+            .max()
+            .unwrap_or(0)
+            .max(record.highest_local_db_version);
+
+        if max_version > self.clock.current_time() {
+            self.clock.set_time(max_version);
         }
         self.data.insert(key, record);
     }

--- a/src/persist/streaming.rs
+++ b/src/persist/streaming.rs
@@ -72,7 +72,7 @@
 //! ```
 
 use crate::{
-    Change, DefaultMergeRule, LogicalClock, NodeId, Record,
+    Change, DefaultMergeRule, NodeId, Record,
     TombstoneInfo, TombstoneStorage, CRDT,
 };
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -95,6 +95,9 @@ const HEADER_SIZE: usize = std::mem::size_of::<NodeId>() + 5 * std::mem::size_of
 
 /// Default LRU cache capacity (number of records)
 pub const DEFAULT_CACHE_CAPACITY: usize = 1000;
+
+/// Result type for migration function to avoid clippy type_complexity warning
+type MigrationResult<K, C, V> = Result<Option<(ColdStorage<K, C, V>, u64, u64)>, PersistError>;
 
 /// Configuration for streaming CRDT
 #[derive(Debug, Clone)]
@@ -173,7 +176,7 @@ impl<K: Hash + Eq + Clone, V> LruCache<K, V> {
         self.map.insert(key, value);
 
         // Compact order queue if it gets too large (prevents unbounded growth)
-        if self.order.len() > self.capacity * 10 {
+        if self.order.len() > self.capacity * 3 {
             self.compact();
         }
     }
@@ -324,6 +327,12 @@ where
         if index_offset == 0 || index_offset >= file_len {
             return Err(PersistError::InvalidDirectory(format!(
                 "Invalid index_offset {} (file_len={})", index_offset, file_len
+            )));
+        }
+        if tombstones_offset == 0 || tombstones_offset >= file_len || tombstones_offset > index_offset {
+            return Err(PersistError::InvalidDirectory(format!(
+                "Invalid tombstones_offset {} (index_offset={}, file_len={})",
+                tombstones_offset, index_offset, file_len
             )));
         }
 
@@ -567,7 +576,7 @@ where
     fn migrate_from_regular_snapshot(
         base_dir: &PathBuf,
         node_id: NodeId,
-    ) -> Result<Option<(ColdStorage<K, C, V>, u64, u64)>, PersistError> {
+    ) -> MigrationResult<K, C, V> {
         // Look for existing MessagePack snapshots
         let mut snapshots: Vec<(u64, PathBuf)> = Vec::new();
 
@@ -710,6 +719,121 @@ where
         std::fs::rename(&temp_path, path)?;
 
         Ok(())
+    }
+
+    /// Create a streaming snapshot without loading all records into memory.
+    /// Returns the final clock value for the snapshot.
+    fn create_streaming_snapshot(&mut self, path: &PathBuf) -> Result<u64, PersistError> {
+        let temp_path = path.with_extension("bin.tmp");
+        let mut file = File::create(&temp_path)?;
+
+        // Write magic and version
+        file.write_all(SNAPSHOT_MAGIC)?;
+        file.write_all(&[SNAPSHOT_VERSION, 0])?;
+
+        // Placeholder for header
+        let header_pos = file.stream_position()?;
+        let placeholder = vec![0u8; HEADER_SIZE];
+        file.write_all(&placeholder)?;
+
+        // Track highest clock value seen
+        let mut max_clock = self.hot.get_clock().current_time();
+
+        // Build index as we write
+        let mut index_entries: Vec<IndexEntry<K>> = Vec::new();
+
+        // 1. Stream cold records that are NOT superseded by hot tier
+        //    This avoids loading all cold records into memory
+        for key in self.cold.keys().cloned().collect::<Vec<_>>() {
+            // Skip if hot has this key (hot data supersedes cold)
+            if self.hot_keys.contains(&key) {
+                continue;
+            }
+            // Skip if tombstoned in hot
+            if self.hot_tombstones.contains(&key) {
+                continue;
+            }
+
+            // Load and write individual record (only one in memory at a time)
+            if let Some(record) = self.cold.load_record(&key)? {
+                max_clock = max_clock.max(record.highest_local_db_version);
+
+                let offset = file.stream_position()?;
+                let record_bytes = rmp_serde::to_vec(&record)
+                    .map_err(PersistError::MsgpackEncode)?;
+                file.write_all(&record_bytes)?;
+
+                index_entries.push(IndexEntry {
+                    key,
+                    offset,
+                    length: record_bytes.len() as u32,
+                    highest_version: record.highest_local_db_version,
+                });
+            }
+        }
+
+        // 2. Write hot tier records (already in memory, no extra load)
+        for (key, record) in self.hot.get_data().iter() {
+            max_clock = max_clock.max(record.highest_local_db_version);
+
+            let offset = file.stream_position()?;
+            let record_bytes = rmp_serde::to_vec(record)
+                .map_err(PersistError::MsgpackEncode)?;
+            file.write_all(&record_bytes)?;
+
+            index_entries.push(IndexEntry {
+                key: key.clone(),
+                offset,
+                length: record_bytes.len() as u32,
+                highest_version: record.highest_local_db_version,
+            });
+        }
+
+        // 3. Merge tombstones from cold and hot
+        let mut tombstone_map: HashMap<K, TombstoneInfo> = HashMap::new();
+
+        // Add cold tombstones not superseded by hot
+        for (key, info) in self.cold.tombstones.iter() {
+            if !self.hot_keys.contains(key) {
+                tombstone_map.insert(key.clone(), *info);
+            }
+        }
+
+        // Add hot tombstones
+        for key in &self.hot_tombstones {
+            if let Some(info) = self.hot.get_tombstones().find(key) {
+                tombstone_map.insert(key.clone(), info);
+            }
+        }
+
+        // Write tombstones section
+        let tombstones_offset = file.stream_position()?;
+        let tombstone_bytes = rmp_serde::to_vec(&tombstone_map)
+            .map_err(PersistError::MsgpackEncode)?;
+        file.write_all(&tombstone_bytes)?;
+
+        // Write index section
+        let index_offset = file.stream_position()?;
+        let index_bytes = rmp_serde::to_vec(&index_entries)
+            .map_err(PersistError::MsgpackEncode)?;
+        file.write_all(&index_bytes)?;
+
+        // Write header
+        file.seek(SeekFrom::Start(header_pos))?;
+        file.write_all(&self.hot.node_id.to_le_bytes())?;
+        file.write_all(&max_clock.to_le_bytes())?;
+        file.write_all(&(index_entries.len() as u64).to_le_bytes())?;
+        file.write_all(&(tombstone_map.len() as u64).to_le_bytes())?;
+        file.write_all(&index_offset.to_le_bytes())?;
+        file.write_all(&tombstones_offset.to_le_bytes())?;
+
+        file.sync_all()?;
+        drop(file);
+
+        // Atomic rename
+        std::fs::rename(&temp_path, path)?;
+
+        Ok(max_clock)
     }
 
     /// Replay WAL files on top of current state
@@ -924,8 +1048,12 @@ where
         }
 
         // Include cold tombstones if they're after last_db_version
+        // Skip if hot has already tombstoned or touched this key
         for (key, info) in self.cold.tombstones.iter() {
-            if info.local_db_version > last_db_version && !self.hot_keys.contains(key) {
+            if info.local_db_version > last_db_version
+                && !self.hot_keys.contains(key)
+                && !self.hot_tombstones.contains(key)
+            {
                 changes.push(Change::new(
                     key.clone(),
                     None,
@@ -946,69 +1074,23 @@ where
     }
 
     /// Create an indexed snapshot of current state
+    ///
+    /// This streams records directly to the snapshot file without loading all
+    /// cold records into memory, making it suitable for large datasets.
     pub fn create_indexed_snapshot(&mut self) -> Result<PathBuf, PersistError> {
-        // Merge hot into a temporary full CRDT for snapshot
-        let mut full_crdt: CRDT<K, C, V> = CRDT::new(self.hot.node_id, None);
-
-        // First, load all cold records (iterate without collecting all keys at once)
-        let cold_keys: Vec<K> = self.cold.keys().cloned().collect();
-        for key in cold_keys {
-            // Skip if hot has this key (hot data supersedes cold)
-            if self.hot_keys.contains(&key) {
-                continue;
-            }
-            // Skip if tombstoned in hot
-            if self.hot_tombstones.contains(&key) {
-                continue;
-            }
-
-            if let Some(record) = self.cold.load_record(&key)? {
-                // Directly insert record (preserves version metadata)
-                full_crdt.insert_record_direct(key, record);
-            }
-        }
-
-        // Apply cold tombstones ONLY if not superseded by hot records
-        for (key, info) in self.cold.tombstones.iter() {
-            // Skip if hot has touched this key (hot data supersedes cold tombstones)
-            if self.hot_keys.contains(key) {
-                continue;
-            }
-            full_crdt.merge_changes(
-                vec![Change::new(
-                    key.clone(),
-                    None,
-                    None,
-                    u64::MAX,
-                    info.db_version,
-                    info.node_id,
-                    info.local_db_version,
-                    0,
-                )],
-                &DefaultMergeRule,
-            );
-        }
-
-        // Merge hot tier on top
-        let hot_changes = self.hot.get_changes_since(0);
-        full_crdt.merge_changes(hot_changes, &DefaultMergeRule);
-
-        // Get the FINAL clock value after all merges (fixes clock desync)
-        let final_clock_value = full_crdt.get_clock().current_time();
-
-        // Create indexed snapshot
         self.snapshot_version += 1;
         let snapshot_path = self.base_dir.join(format!(
             "snapshot_indexed_{:06}.bin",
             self.snapshot_version
         ));
 
-        Self::create_indexed_snapshot_from_crdt(&full_crdt, self.hot.node_id, &snapshot_path)?;
+        // Stream snapshot directly to file (avoids memory explosion)
+        let final_clock_value = self.create_streaming_snapshot(&snapshot_path)?;
 
         // Reload cold storage from new snapshot
         self.cold = ColdStorage::from_file(&snapshot_path)?;
 
-        // Clear hot tier with FINAL clock value (fixes clock desync)
+        // Clear hot tier with final clock value
         self.hot = CRDT::new(self.hot.node_id, None);
         self.hot.get_clock_mut().set_time(final_clock_value);
         self.hot_keys.clear();
@@ -1062,15 +1144,19 @@ where
         self.cold.len()
     }
 
-    /// Get total number of records (hot + cold, excluding duplicates)
+    /// Get total number of active records (hot + cold, excluding duplicates and tombstones)
     ///
     /// Note: Records in hot tier that supersede cold records are counted once.
+    /// Tombstoned records are not counted.
     pub fn total_record_count(&self) -> usize {
-        // Cold records not in hot + hot records
+        // Cold records not in hot and not tombstoned
         let cold_only = self.cold.index.keys()
             .filter(|k| !self.hot_keys.contains(*k) && !self.hot_tombstones.contains(*k))
+            .filter(|k| !self.cold.is_tombstoned(*k))
             .count();
-        cold_only + self.hot_keys.len()
+        // Hot records minus hot tombstones
+        let hot_active = self.hot_keys.len().saturating_sub(self.hot_tombstones.len());
+        cold_only + hot_active
     }
 
     /// Get current logical clock value
@@ -1152,38 +1238,6 @@ where
         }
 
         Ok(())
-    }
-}
-
-// Internal CRDT extensions for streaming module
-impl<K: Ord + Hash + Eq + Clone, C: Hash + Eq + Clone, V: Clone> CRDT<K, C, V> {
-    /// Mutable access to the logical clock (for internal use)
-    pub(crate) fn get_clock_mut(&mut self) -> &mut LogicalClock {
-        &mut self.clock
-    }
-
-    /// Access to tombstones (for internal use)
-    pub(crate) fn get_tombstones(&self) -> &TombstoneStorage<K> {
-        &self.tombstones
-    }
-
-    /// Insert a record directly, preserving its version metadata.
-    /// This bypasses the normal change-based API to avoid causality issues
-    /// when loading cold records into hot storage.
-    pub(crate) fn insert_record_direct(&mut self, key: K, record: Record<C, V>) {
-        // Update clock to at least match the record's versions
-        // Check both column versions and highest_local_db_version to handle all cases
-        let max_version = record.column_versions
-            .values()
-            .map(|v| v.db_version)
-            .max()
-            .unwrap_or(0)
-            .max(record.highest_local_db_version);
-
-        if max_version > self.clock.current_time() {
-            self.clock.set_time(max_version);
-        }
-        self.data.insert(key, record);
     }
 }
 

--- a/src/persist/streaming.rs
+++ b/src/persist/streaming.rs
@@ -25,7 +25,7 @@
 //! ├── magic: "CRDS" (4 bytes)
 //! ├── version: u8
 //! ├── flags: u8
-//! ├── node_id: u64
+//! ├── node_id: NodeId (8 or 16 bytes depending on feature)
 //! ├── clock_value: u64
 //! ├── record_count: u64
 //! ├── tombstone_count: u64
@@ -41,7 +41,7 @@
 //! └── HashMap<K, TombstoneInfo> (MessagePack serialized)
 //!
 //! [Index Section] (loaded at startup)
-//! └── Vec<(K, offset, length)> (MessagePack serialized)
+//! └── Vec<IndexEntry { key: K, offset: u64, length: u32 }> (MessagePack serialized)
 //! ```
 //!
 //! # Example
@@ -75,7 +75,7 @@ use crate::{
     Change, DefaultMergeRule, LogicalClock, NodeId, Record,
     TombstoneInfo, TombstoneStorage, CRDT,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs::File;
 use std::hash::Hash;
 use std::io::{BufReader, Read, Seek, SeekFrom, Write};
@@ -123,28 +123,32 @@ struct IndexEntry<K> {
     length: u32,
 }
 
-
-/// Simple LRU cache implementation
+/// O(1) LRU cache implementation using HashMap + VecDeque with reference counting
 struct LruCache<K, V> {
     capacity: usize,
     map: HashMap<K, V>,
-    order: Vec<K>, // Most recently used at the end
+    /// Keys in order of access (oldest at front, newest at back)
+    order: VecDeque<K>,
+    /// Count how many times each key appears in the order queue
+    /// Only evict when count reaches 0
+    ref_count: HashMap<K, usize>,
 }
 
 impl<K: Hash + Eq + Clone, V> LruCache<K, V> {
     fn new(capacity: usize) -> Self {
         Self {
-            capacity,
-            map: HashMap::new(),
-            order: Vec::new(),
+            capacity: capacity.max(1), // Ensure at least 1
+            map: HashMap::with_capacity(capacity),
+            order: VecDeque::with_capacity(capacity * 2),
+            ref_count: HashMap::with_capacity(capacity),
         }
     }
 
     fn get(&mut self, key: &K) -> Option<&V> {
         if self.map.contains_key(key) {
-            // Move to end (most recently used)
-            self.order.retain(|k| k != key);
-            self.order.push(key.clone());
+            // Mark as recently used by adding to back
+            self.order.push_back(key.clone());
+            *self.ref_count.entry(key.clone()).or_insert(0) += 1;
             self.map.get(key)
         } else {
             None
@@ -152,22 +156,48 @@ impl<K: Hash + Eq + Clone, V> LruCache<K, V> {
     }
 
     fn insert(&mut self, key: K, value: V) {
-        if self.map.contains_key(&key) {
-            // Update existing
-            self.order.retain(|k| k != &key);
-        } else if self.map.len() >= self.capacity {
-            // Evict oldest
-            if let Some(oldest) = self.order.first().cloned() {
-                self.order.remove(0);
-                self.map.remove(&oldest);
+        if !self.map.contains_key(&key) {
+            // Evict if at capacity
+            while self.map.len() >= self.capacity {
+                self.evict_one();
             }
         }
-        self.order.push(key.clone());
+        self.order.push_back(key.clone());
+        *self.ref_count.entry(key.clone()).or_insert(0) += 1;
         self.map.insert(key, value);
+    }
+
+    fn evict_one(&mut self) {
+        // Pop from front until we find a key with ref_count == 1 (last reference)
+        while let Some(oldest) = self.order.pop_front() {
+            let count = self.ref_count.get_mut(&oldest);
+            match count {
+                Some(c) if *c > 1 => {
+                    // Key has newer references, skip this stale one
+                    *c -= 1;
+                }
+                Some(_) => {
+                    // Last reference, evict this key
+                    self.ref_count.remove(&oldest);
+                    self.map.remove(&oldest);
+                    break;
+                }
+                None => {
+                    // Key not in map (already evicted), continue
+                }
+            }
+        }
     }
 
     fn contains_key(&self, key: &K) -> bool {
         self.map.contains_key(key)
+    }
+
+    #[allow(dead_code)]
+    fn clear(&mut self) {
+        self.map.clear();
+        self.order.clear();
+        self.ref_count.clear();
     }
 }
 
@@ -288,9 +318,8 @@ where
             tombstones.insert_or_assign(key, info);
         }
 
-        // Reopen file for record access
-        let file = File::open(path)?;
-        let reader = BufReader::new(file);
+        // Reuse the same reader - just seek when needed for record access
+        // No need to reopen the file (fixes file descriptor leak)
 
         Ok(Self {
             file: Some(reader),
@@ -335,12 +364,11 @@ where
     }
 
     /// Get tombstone info
-    #[allow(dead_code)]
     fn get_tombstone(&self, key: &K) -> Option<TombstoneInfo> {
         self.tombstones.find(key)
     }
 
-    /// Get all keys in cold storage
+    /// Iterate over keys (without collecting into Vec to save memory)
     fn keys(&self) -> impl Iterator<Item = &K> {
         self.index.keys()
     }
@@ -414,20 +442,20 @@ where
     ) -> Result<Self, PersistError> {
         std::fs::create_dir_all(&base_dir)?;
 
-        // Look for indexed snapshot
-        let indexed_snapshot = Self::find_indexed_snapshot(&base_dir)?;
+        // Look for indexed snapshot and extract version
+        let (indexed_snapshot, snapshot_version) = Self::find_indexed_snapshot(&base_dir)?;
 
-        let (cold, clock_value) = if let Some(path) = indexed_snapshot {
+        let (cold, clock_value, snapshot_version) = if let Some(path) = indexed_snapshot {
             let cold = ColdStorage::from_file(&path)?;
             let clock = cold.clock_value;
-            (cold, clock)
+            (cold, clock, snapshot_version)
         } else {
             // Try to migrate from regular snapshot
             let migrated = Self::migrate_from_regular_snapshot(&base_dir, node_id)?;
-            if let Some((cold, clock)) = migrated {
-                (cold, clock)
+            if let Some((cold, clock, version)) = migrated {
+                (cold, clock, version)
             } else {
-                (ColdStorage::empty(), 0)
+                (ColdStorage::empty(), 0, 0)
             }
         };
 
@@ -452,7 +480,7 @@ where
             config,
             base_dir,
             changes_since_snapshot: 0,
-            snapshot_version: 0,
+            snapshot_version,
             post_hooks: Vec::new(),
             snapshot_hooks: Vec::new(),
             wal_segment_hooks: Vec::new(),
@@ -465,8 +493,8 @@ where
         Ok(streaming)
     }
 
-    /// Find the most recent indexed snapshot
-    fn find_indexed_snapshot(base_dir: &PathBuf) -> Result<Option<PathBuf>, PersistError> {
+    /// Find the most recent indexed snapshot and return its version
+    fn find_indexed_snapshot(base_dir: &PathBuf) -> Result<(Option<PathBuf>, u64), PersistError> {
         let mut snapshots: Vec<(u64, PathBuf)> = Vec::new();
 
         if let Ok(entries) = std::fs::read_dir(base_dir) {
@@ -491,14 +519,17 @@ where
         }
 
         snapshots.sort_by_key(|(v, _)| *v);
-        Ok(snapshots.last().map(|(_, p)| p.clone()))
+        match snapshots.last() {
+            Some((version, path)) => Ok((Some(path.clone()), *version)),
+            None => Ok((None, 0)),
+        }
     }
 
     /// Migrate from a regular PersistedCRDT snapshot to indexed format
     fn migrate_from_regular_snapshot(
         base_dir: &PathBuf,
         node_id: NodeId,
-    ) -> Result<Option<(ColdStorage<K, C, V>, u64)>, PersistError> {
+    ) -> Result<Option<(ColdStorage<K, C, V>, u64, u64)>, PersistError> {
         // Look for existing MessagePack snapshots
         let mut snapshots: Vec<(u64, PathBuf)> = Vec::new();
 
@@ -528,6 +559,7 @@ where
 
         snapshots.sort_by_key(|(v, _)| *v);
         let (version, path) = snapshots.last().unwrap();
+        let version = *version;
 
         // Load the regular snapshot
         let bytes = std::fs::read(path)?;
@@ -559,24 +591,27 @@ where
 
         let clock_value = crdt.get_clock().current_time();
 
-        // Create indexed snapshot from the loaded CRDT
+        // Create indexed snapshot from the loaded CRDT (with atomic write)
         let indexed_path = base_dir.join(format!("snapshot_indexed_{:06}.bin", version));
         Self::create_indexed_snapshot_from_crdt(&crdt, node_id, &indexed_path)?;
 
         // Load the new indexed snapshot
         let cold = ColdStorage::from_file(&indexed_path)?;
 
-        Ok(Some((cold, clock_value)))
+        Ok(Some((cold, clock_value, version)))
     }
 
-    /// Create an indexed snapshot from a CRDT
+    /// Create an indexed snapshot from a CRDT (atomic write via temp file)
     fn create_indexed_snapshot_from_crdt(
         crdt: &CRDT<K, C, V>,
         node_id: NodeId,
         path: &PathBuf,
     ) -> Result<(), PersistError> {
+        // Write to a temp file first, then rename atomically
+        let temp_path = path.with_extension("bin.tmp");
+
         // Use unbuffered I/O to avoid issues with seeking and stream_position
-        let mut file = File::create(path)?;
+        let mut file = File::create(&temp_path)?;
 
         // Write magic and version
         file.write_all(SNAPSHOT_MAGIC)?;
@@ -630,6 +665,10 @@ where
         file.write_all(&tombstones_offset.to_le_bytes())?;
 
         file.sync_all()?;
+        drop(file);
+
+        // Atomic rename
+        std::fs::rename(&temp_path, path)?;
 
         Ok(())
     }
@@ -655,6 +694,7 @@ where
 
         for entry in wal_files {
             let changes: Vec<Change<K, C, V>> = super::wal::read_wal_file(&entry.path())?;
+            let num_changes = changes.len();
             for change in &changes {
                 // Apply to hot tier
                 self.hot_keys.insert(change.record_id.clone());
@@ -664,7 +704,7 @@ where
             }
             // Merge the changes
             self.hot.merge_changes(changes, &DefaultMergeRule);
-            self.changes_since_snapshot += 1;
+            self.changes_since_snapshot += num_changes; // Fix: count actual changes
         }
 
         Ok(())
@@ -732,8 +772,9 @@ where
         // If record exists in cold but not hot, load it first
         if !self.hot_keys.contains(record_id) && self.cold.contains_key(record_id) {
             if let Some(cold_record) = self.cold.load_record(record_id)? {
-                // Merge cold record into hot
-                self.merge_cold_record_to_hot(record_id, cold_record);
+                // Directly insert cold record into hot storage (preserves version metadata)
+                self.hot.insert_record_direct(record_id.clone(), cold_record);
+                self.hot_keys.insert(record_id.clone());
             }
         }
 
@@ -773,7 +814,9 @@ where
                 && self.cold.contains_key(&change.record_id)
             {
                 if let Some(cold_record) = self.cold.load_record(&change.record_id)? {
-                    self.merge_cold_record_to_hot(&change.record_id, cold_record);
+                    // Directly insert cold record into hot storage (preserves version metadata)
+                    self.hot.insert_record_direct(change.record_id.clone(), cold_record);
+                    self.hot_keys.insert(change.record_id.clone());
                 }
             }
         }
@@ -796,13 +839,63 @@ where
     }
 
     /// Get changes since a version (for sync)
+    ///
+    /// This scans both hot and cold storage to ensure all changes are included.
     pub fn get_changes_since(&mut self, last_db_version: u64) -> Result<Vec<Change<K, C, V>>, PersistError> {
         // Hot tier changes
         let mut changes = self.hot.get_changes_since(last_db_version);
 
-        // For cold records not in hot, we'd need to scan - but typically
-        // get_changes_since is called for recent changes which are in hot
-        // This is a trade-off for streaming: old cold changes require full scan
+        // Scan cold storage for records with changes after last_db_version
+        // This is necessary to ensure sync completeness
+        for key in self.cold.keys().cloned().collect::<Vec<_>>() {
+            // Skip if already in hot (hot has newer data)
+            if self.hot_keys.contains(&key) {
+                continue;
+            }
+            // Skip if tombstoned
+            if self.hot_tombstones.contains(&key) {
+                continue;
+            }
+
+            if let Some(record) = self.cold.load_record(&key)? {
+                // Check if record has changes after last_db_version
+                if record.highest_local_db_version > last_db_version {
+                    // Convert record to changes
+                    for (col_name, value) in &record.fields {
+                        if let Some(col_ver) = record.column_versions.get(col_name) {
+                            if col_ver.local_db_version > last_db_version {
+                                changes.push(Change::new(
+                                    key.clone(),
+                                    Some(col_name.clone()),
+                                    Some(value.clone()),
+                                    col_ver.col_version,
+                                    col_ver.db_version,
+                                    col_ver.node_id,
+                                    col_ver.local_db_version,
+                                    0,
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Include cold tombstones if they're after last_db_version
+        for (key, info) in self.cold.tombstones.iter() {
+            if info.local_db_version > last_db_version && !self.hot_keys.contains(key) {
+                changes.push(Change::new(
+                    key.clone(),
+                    None,
+                    None,
+                    u64::MAX,
+                    info.db_version,
+                    info.node_id,
+                    info.local_db_version,
+                    0,
+                ));
+            }
+        }
 
         // Sort and dedupe
         CRDT::compress_changes(&mut changes);
@@ -815,19 +908,30 @@ where
         // Merge hot into a temporary full CRDT for snapshot
         let mut full_crdt: CRDT<K, C, V> = CRDT::new(self.hot.node_id, None);
 
-        // First, load all cold records
-        for key in self.cold.keys().cloned().collect::<Vec<_>>() {
-            if !self.hot_tombstones.contains(&key) {
-                if let Some(record) = self.cold.load_record(&key)? {
-                    // Convert record to changes and merge
-                    let changes = self.record_to_changes(&key, &record);
-                    full_crdt.merge_changes(changes, &DefaultMergeRule);
-                }
+        // First, load all cold records (iterate without collecting all keys at once)
+        let cold_keys: Vec<K> = self.cold.keys().cloned().collect();
+        for key in cold_keys {
+            // Skip if hot has this key (hot data supersedes cold)
+            if self.hot_keys.contains(&key) {
+                continue;
+            }
+            // Skip if tombstoned in hot
+            if self.hot_tombstones.contains(&key) {
+                continue;
+            }
+
+            if let Some(record) = self.cold.load_record(&key)? {
+                // Directly insert record (preserves version metadata)
+                full_crdt.insert_record_direct(key, record);
             }
         }
 
-        // Apply cold tombstones
+        // Apply cold tombstones ONLY if not superseded by hot records
         for (key, info) in self.cold.tombstones.iter() {
+            // Skip if hot has touched this key (hot data supersedes cold tombstones)
+            if self.hot_keys.contains(key) {
+                continue;
+            }
             full_crdt.merge_changes(
                 vec![Change::new(
                     key.clone(),
@@ -847,6 +951,9 @@ where
         let hot_changes = self.hot.get_changes_since(0);
         full_crdt.merge_changes(hot_changes, &DefaultMergeRule);
 
+        // Get the FINAL clock value after all merges (fixes clock desync)
+        let final_clock_value = full_crdt.get_clock().current_time();
+
         // Create indexed snapshot
         self.snapshot_version += 1;
         let snapshot_path = self.base_dir.join(format!(
@@ -859,9 +966,9 @@ where
         // Reload cold storage from new snapshot
         self.cold = ColdStorage::from_file(&snapshot_path)?;
 
-        // Clear hot tier
+        // Clear hot tier with FINAL clock value (fixes clock desync)
         self.hot = CRDT::new(self.hot.node_id, None);
-        self.hot.get_clock_mut().set_time(self.cold.clock_value);
+        self.hot.get_clock_mut().set_time(final_clock_value);
         self.hot_keys.clear();
         self.hot_tombstones.clear();
         self.cache = LruCache::new(self.config.cache_capacity);
@@ -916,33 +1023,6 @@ where
     /// Get current logical clock value
     pub fn get_clock_time(&self) -> u64 {
         self.hot.get_clock().current_time()
-    }
-
-    // Helper methods
-
-    fn merge_cold_record_to_hot(&mut self, key: &K, record: Record<C, V>) {
-        let changes = self.record_to_changes(key, &record);
-        self.hot.merge_changes(changes, &DefaultMergeRule);
-        self.hot_keys.insert(key.clone());
-    }
-
-    fn record_to_changes(&self, key: &K, record: &Record<C, V>) -> Vec<Change<K, C, V>> {
-        let mut changes = Vec::new();
-        for (col_name, value) in &record.fields {
-            if let Some(col_ver) = record.column_versions.get(col_name) {
-                changes.push(Change::new(
-                    key.clone(),
-                    Some(col_name.clone()),
-                    Some(value.clone()),
-                    col_ver.col_version,
-                    col_ver.db_version,
-                    col_ver.node_id,
-                    col_ver.local_db_version,
-                    0,
-                ));
-            }
-        }
-        changes
     }
 
     /// Delete all WAL files except the current one
@@ -1015,9 +1095,7 @@ where
     }
 }
 
-// Need to add get_clock_mut and get_tombstones to CRDT - let's do that via a trait extension
-// For now, we'll work around it
-
+// Internal CRDT extensions for streaming module
 impl<K: Ord + Hash + Eq + Clone, C: Hash + Eq + Clone, V: Clone> CRDT<K, C, V> {
     /// Mutable access to the logical clock (for internal use)
     pub(crate) fn get_clock_mut(&mut self) -> &mut LogicalClock {
@@ -1027,6 +1105,19 @@ impl<K: Ord + Hash + Eq + Clone, C: Hash + Eq + Clone, V: Clone> CRDT<K, C, V> {
     /// Access to tombstones (for internal use)
     pub(crate) fn get_tombstones(&self) -> &TombstoneStorage<K> {
         &self.tombstones
+    }
+
+    /// Insert a record directly, preserving its version metadata.
+    /// This bypasses the normal change-based API to avoid causality issues
+    /// when loading cold records into hot storage.
+    pub(crate) fn insert_record_direct(&mut self, key: K, record: Record<C, V>) {
+        // Update clock to at least match the record's versions
+        for col_ver in record.column_versions.values() {
+            if col_ver.db_version > self.clock.current_time() {
+                self.clock.set_time(col_ver.db_version);
+            }
+        }
+        self.data.insert(key, record);
     }
 }
 
@@ -1170,5 +1261,127 @@ mod tests {
             assert_eq!(record.fields.get("field1").unwrap(), "hot_value");
             assert_eq!(record.fields.get("field2").unwrap(), "unchanged");
         }
+    }
+
+    #[test]
+    fn test_get_changes_since_includes_cold() {
+        let temp_dir = TempDir::new().unwrap();
+        let base_dir = temp_dir.path().to_path_buf();
+
+        // Create data and snapshot
+        {
+            let mut crdt = StreamingCRDT::<String, String, String>::open(
+                base_dir.clone(),
+                1,
+                StreamingConfig::default(),
+            )
+            .unwrap();
+
+            crdt.insert_or_update(
+                &"key1".to_string(),
+                vec![("field1".to_string(), "value1".to_string())],
+            )
+            .unwrap();
+
+            crdt.create_indexed_snapshot().unwrap();
+        }
+
+        // Reopen and verify get_changes_since includes cold records
+        {
+            let mut crdt = StreamingCRDT::<String, String, String>::open(
+                base_dir.clone(),
+                1,
+                StreamingConfig::default(),
+            )
+            .unwrap();
+
+            // Should find changes from cold storage when asking for version 0
+            let changes = crdt.get_changes_since(0).unwrap();
+            assert!(!changes.is_empty(), "Should find cold changes");
+
+            // Verify the change is for key1
+            assert!(
+                changes.iter().any(|c| c.record_id == "key1"),
+                "Should find change for key1"
+            );
+
+            // Should not find changes after the current clock (future)
+            let current_clock = crdt.get_clock_time();
+            let no_changes = crdt.get_changes_since(current_clock + 100).unwrap();
+            assert!(no_changes.is_empty(), "Should not find changes in the future");
+        }
+    }
+
+    #[test]
+    fn test_clock_preserved_across_snapshots() {
+        let temp_dir = TempDir::new().unwrap();
+        let base_dir = temp_dir.path().to_path_buf();
+
+        let clock_before_snapshot;
+        let clock_after_snapshot;
+        {
+            let mut crdt = StreamingCRDT::<String, String, String>::open(
+                base_dir.clone(),
+                1,
+                StreamingConfig::default(),
+            )
+            .unwrap();
+
+            for i in 0..10 {
+                crdt.insert_or_update(
+                    &format!("key{}", i),
+                    vec![("field".to_string(), format!("value{}", i))],
+                )
+                .unwrap();
+            }
+
+            clock_before_snapshot = crdt.get_clock_time();
+            crdt.create_indexed_snapshot().unwrap();
+            clock_after_snapshot = crdt.get_clock_time();
+
+            // Clock should be at least as high after snapshot (merge may advance it)
+            assert!(
+                clock_after_snapshot >= clock_before_snapshot,
+                "Clock should not go backwards"
+            );
+        }
+
+        // Reopen and verify clock is preserved
+        {
+            let crdt = StreamingCRDT::<String, String, String>::open(
+                base_dir.clone(),
+                1,
+                StreamingConfig::default(),
+            )
+            .unwrap();
+
+            // Clock should match what it was after snapshot
+            assert_eq!(crdt.get_clock_time(), clock_after_snapshot);
+        }
+    }
+
+    #[test]
+    fn test_lru_cache_eviction() {
+        let mut cache: LruCache<i32, String> = LruCache::new(3);
+
+        cache.insert(1, "one".to_string());
+        cache.insert(2, "two".to_string());
+        cache.insert(3, "three".to_string());
+
+        // All should be present
+        assert!(cache.contains_key(&1));
+        assert!(cache.contains_key(&2));
+        assert!(cache.contains_key(&3));
+
+        // Access 1 to make it recently used
+        let _ = cache.get(&1);
+
+        // Insert 4, should evict 2 (oldest)
+        cache.insert(4, "four".to_string());
+
+        assert!(cache.contains_key(&1)); // Still there (was accessed)
+        assert!(!cache.contains_key(&2)); // Evicted
+        assert!(cache.contains_key(&3));
+        assert!(cache.contains_key(&4));
     }
 }

--- a/src/persist/streaming.rs
+++ b/src/persist/streaming.rs
@@ -78,7 +78,7 @@ use crate::{
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::hash::Hash;
-use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
+use std::io::{BufReader, Read, Seek, SeekFrom, Write};
 use std::path::PathBuf;
 
 use super::wal::WalWriter;
@@ -88,6 +88,10 @@ use super::{PersistConfig, PersistError, PostOpHook, SnapshotHook, WalSegmentHoo
 const SNAPSHOT_MAGIC: &[u8; 4] = b"CRDS";
 /// Current snapshot format version
 const SNAPSHOT_VERSION: u8 = 1;
+
+/// Header size depends on NodeId type
+/// Layout: node_id + clock + record_count + tombstone_count + index_offset + tombstones_offset
+const HEADER_SIZE: usize = std::mem::size_of::<NodeId>() + 5 * std::mem::size_of::<u64>();
 
 /// Default LRU cache capacity (number of records)
 pub const DEFAULT_CACHE_CAPACITY: usize = 1000;
@@ -206,6 +210,7 @@ where
     /// Load cold storage from an indexed snapshot file
     fn from_file(path: &PathBuf) -> Result<Self, PersistError> {
         let file = File::open(path)?;
+        let file_len = file.metadata()?.len();
         let mut reader = BufReader::new(file);
 
         // Read and verify magic
@@ -230,17 +235,38 @@ where
         // flags[1] reserved for future use
 
         // Read header fields
-        let mut header_buf = [0u8; 48]; // 6 * u64
+        let mut header_buf = vec![0u8; HEADER_SIZE];
         reader.read_exact(&mut header_buf)?;
 
-        let node_id = u64::from_le_bytes(header_buf[0..8].try_into().unwrap());
-        let clock_value = u64::from_le_bytes(header_buf[8..16].try_into().unwrap());
-        let record_count = u64::from_le_bytes(header_buf[16..24].try_into().unwrap());
-        let tombstone_count = u64::from_le_bytes(header_buf[24..32].try_into().unwrap());
-        let index_offset = u64::from_le_bytes(header_buf[32..40].try_into().unwrap());
-        let tombstones_offset = u64::from_le_bytes(header_buf[40..48].try_into().unwrap());
+        // Parse header - NodeId size varies based on feature flag
+        let node_id_size = std::mem::size_of::<NodeId>();
+        let mut offset = 0;
 
-        let _ = (node_id, record_count, tombstone_count); // Silence unused warnings
+        // Skip node_id (we don't need it for loading)
+        offset += node_id_size;
+
+        let clock_value = u64::from_le_bytes(header_buf[offset..offset + 8].try_into().unwrap());
+        offset += 8;
+
+        let record_count = u64::from_le_bytes(header_buf[offset..offset + 8].try_into().unwrap());
+        offset += 8;
+
+        let tombstone_count = u64::from_le_bytes(header_buf[offset..offset + 8].try_into().unwrap());
+        offset += 8;
+
+        let index_offset = u64::from_le_bytes(header_buf[offset..offset + 8].try_into().unwrap());
+        offset += 8;
+
+        let tombstones_offset = u64::from_le_bytes(header_buf[offset..offset + 8].try_into().unwrap());
+
+        let _ = (record_count, tombstone_count); // Silence unused warnings
+
+        // Validate offsets
+        if index_offset == 0 || index_offset >= file_len {
+            return Err(PersistError::InvalidDirectory(format!(
+                "Invalid index_offset {} (file_len={})", index_offset, file_len
+            )));
+        }
 
         // Load index from end of file
         reader.seek(SeekFrom::Start(index_offset))?;
@@ -549,27 +575,26 @@ where
         node_id: NodeId,
         path: &PathBuf,
     ) -> Result<(), PersistError> {
-        let file = File::create(path)?;
-        let mut writer = BufWriter::new(file);
+        // Use unbuffered I/O to avoid issues with seeking and stream_position
+        let mut file = File::create(path)?;
 
         // Write magic and version
-        writer.write_all(SNAPSHOT_MAGIC)?;
-        writer.write_all(&[SNAPSHOT_VERSION, 0])?; // version, flags
+        file.write_all(SNAPSHOT_MAGIC)?;
+        file.write_all(&[SNAPSHOT_VERSION, 0])?; // version, flags
 
         // Placeholder for header (we'll seek back and write it)
-        let header_pos = writer.stream_position()?;
-        let placeholder = [0u8; 48];
-        writer.write_all(&placeholder)?;
+        let header_pos = file.stream_position()?;
+        let placeholder = vec![0u8; HEADER_SIZE];
+        file.write_all(&placeholder)?;
 
         // Write records and build index
         let mut index_entries: Vec<IndexEntry<K>> = Vec::new();
-        let records_start = writer.stream_position()?;
 
         for (key, record) in crdt.get_data().iter() {
-            let offset = writer.stream_position()?;
+            let offset = file.stream_position()?;
             let record_bytes =
                 rmp_serde::to_vec(record).map_err(PersistError::MsgpackEncode)?;
-            writer.write_all(&record_bytes)?;
+            file.write_all(&record_bytes)?;
 
             index_entries.push(IndexEntry {
                 key: key.clone(),
@@ -579,7 +604,7 @@ where
         }
 
         // Write tombstones section
-        let tombstones_offset = writer.stream_position()?;
+        let tombstones_offset = file.stream_position()?;
         let tombstone_map: HashMap<K, TombstoneInfo> = crdt
             .get_tombstones()
             .iter()
@@ -587,27 +612,24 @@ where
             .collect();
         let tombstone_bytes =
             rmp_serde::to_vec(&tombstone_map).map_err(PersistError::MsgpackEncode)?;
-        writer.write_all(&tombstone_bytes)?;
+        file.write_all(&tombstone_bytes)?;
 
         // Write index section
-        let index_offset = writer.stream_position()?;
+        let index_offset = file.stream_position()?;
         let index_bytes =
             rmp_serde::to_vec(&index_entries).map_err(PersistError::MsgpackEncode)?;
-        writer.write_all(&index_bytes)?;
+        file.write_all(&index_bytes)?;
 
-        // Write header
-        writer.seek(SeekFrom::Start(header_pos))?;
-        writer.write_all(&node_id.to_le_bytes())?;
-        writer.write_all(&crdt.get_clock().current_time().to_le_bytes())?;
-        writer.write_all(&(index_entries.len() as u64).to_le_bytes())?;
-        writer.write_all(&(tombstone_map.len() as u64).to_le_bytes())?;
-        writer.write_all(&index_offset.to_le_bytes())?;
-        writer.write_all(&tombstones_offset.to_le_bytes())?;
+        // Write header - seek back and overwrite placeholder
+        file.seek(SeekFrom::Start(header_pos))?;
+        file.write_all(&node_id.to_le_bytes())?;
+        file.write_all(&crdt.get_clock().current_time().to_le_bytes())?;
+        file.write_all(&(index_entries.len() as u64).to_le_bytes())?;
+        file.write_all(&(tombstone_map.len() as u64).to_le_bytes())?;
+        file.write_all(&index_offset.to_le_bytes())?;
+        file.write_all(&tombstones_offset.to_le_bytes())?;
 
-        writer.flush()?;
-        writer.get_ref().sync_all()?;
-
-        let _ = records_start; // Silence unused warning
+        file.sync_all()?;
 
         Ok(())
     }

--- a/src/persist/streaming.rs
+++ b/src/persist/streaming.rs
@@ -734,17 +734,15 @@ where
     let mut index_entries: Vec<IndexEntry<K>> = Vec::new();
 
     // 1. Stream cold records that are NOT superseded by hot tier
-    //    This avoids loading all cold records into memory
-    for key in self.cold.keys().cloned().collect::<Vec<_>>() {
-      // Skip if hot has this key (hot data supersedes cold)
-      if self.hot_keys.contains(&key) {
-        continue;
-      }
-      // Skip if tombstoned in hot
-      if self.hot_tombstones.contains(&key) {
-        continue;
-      }
+    //    Filter before collecting to reduce memory usage
+    let cold_keys_to_process: Vec<K> = self
+      .cold
+      .keys()
+      .filter(|k| !self.hot_keys.contains(*k) && !self.hot_tombstones.contains(*k))
+      .cloned()
+      .collect();
 
+    for key in cold_keys_to_process {
       // Load and write individual record (only one in memory at a time)
       if let Some(record) = self.cold.load_record(&key)? {
         max_clock = max_clock.max(record.highest_local_db_version);
@@ -807,7 +805,7 @@ where
 
     // Write header
     file.seek(SeekFrom::Start(header_pos))?;
-    file.write_all(&self.hot.node_id.to_le_bytes())?;
+    file.write_all(&self.hot.node_id().to_le_bytes())?;
     file.write_all(&max_clock.to_le_bytes())?;
     file.write_all(&(index_entries.len() as u64).to_le_bytes())?;
     file.write_all(&(tombstone_map.len() as u64).to_le_bytes())?;
@@ -1083,7 +1081,7 @@ where
     self.cold = ColdStorage::from_file(&snapshot_path)?;
 
     // Clear hot tier with final clock value
-    self.hot = CRDT::new(self.hot.node_id, None);
+    self.hot = CRDT::new(self.hot.node_id(), None);
     self.hot.get_clock_mut().set_time(final_clock_value);
     self.hot_keys.clear();
     self.hot_tombstones.clear();

--- a/src/persist/streaming.rs
+++ b/src/persist/streaming.rs
@@ -1138,7 +1138,7 @@ where
       .hot_tombstones
       .iter()
       .filter(|k| {
-        if let Some(info) = self.hot.get_tombstones().find(*k) {
+        if self.hot.get_tombstones().find(*k).is_some() {
           false // Still exists, don't remove from tracking
         } else {
           true // Was compacted, remove from tracking

--- a/src/persist/streaming.rs
+++ b/src/persist/streaming.rs
@@ -1,0 +1,1152 @@
+//! Disk-streaming CRDT with lazy loading for massive datasets.
+//!
+//! This module provides `StreamingCRDT`, a disk-backed CRDT that:
+//! - Loads records on-demand from indexed snapshots
+//! - Keeps recent changes in a hot in-memory tier
+//! - Uses an LRU cache for frequently accessed cold records
+//! - Supports datasets larger than available memory
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────┐
+//! │         Hot Tier (Memory)           │  ← Recent writes, always in memory
+//! ├─────────────────────────────────────┤
+//! │         LRU Cache (Memory)          │  ← Frequently accessed cold records
+//! ├─────────────────────────────────────┤
+//! │     Indexed Snapshot (Disk)         │  ← All records, loaded on-demand
+//! └─────────────────────────────────────┘
+//! ```
+//!
+//! # Indexed Snapshot Format
+//!
+//! ```text
+//! [Header]
+//! ├── magic: "CRDS" (4 bytes)
+//! ├── version: u8
+//! ├── flags: u8
+//! ├── node_id: u64
+//! ├── clock_value: u64
+//! ├── record_count: u64
+//! ├── tombstone_count: u64
+//! ├── index_offset: u64
+//! ├── tombstones_offset: u64
+//!
+//! [Records Section]
+//! ├── record_1 (MessagePack serialized)
+//! ├── record_2 (MessagePack serialized)
+//! └── ...
+//!
+//! [Tombstones Section] (loaded at startup - typically small)
+//! └── HashMap<K, TombstoneInfo> (MessagePack serialized)
+//!
+//! [Index Section] (loaded at startup)
+//! └── Vec<(K, offset, length)> (MessagePack serialized)
+//! ```
+//!
+//! # Example
+//!
+//! ```no_run
+//! use crdt_lite::persist::streaming::{StreamingCRDT, StreamingConfig};
+//! use std::path::PathBuf;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // Open with 1000-record LRU cache
+//! let mut crdt = StreamingCRDT::<String, String, String>::open(
+//!     PathBuf::from("./data"),
+//!     1,
+//!     StreamingConfig::default(),
+//! )?;
+//!
+//! // Operations work the same as regular CRDT
+//! crdt.insert_or_update(&"key1".to_string(), vec![
+//!     ("field".to_string(), "value".to_string()),
+//! ])?;
+//!
+//! // Records are loaded on-demand
+//! if let Some(record) = crdt.get_record(&"key1".to_string())? {
+//!     println!("Found: {:?}", record);
+//! }
+//! # Ok(())
+//! # }
+//! ```
+
+use crate::{
+    Change, DefaultMergeRule, LogicalClock, NodeId, Record,
+    TombstoneInfo, TombstoneStorage, CRDT,
+};
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::hash::Hash;
+use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
+use std::path::PathBuf;
+
+use super::wal::WalWriter;
+use super::{PersistConfig, PersistError, PostOpHook, SnapshotHook, WalSegmentHook};
+
+/// Magic bytes for indexed snapshot format
+const SNAPSHOT_MAGIC: &[u8; 4] = b"CRDS";
+/// Current snapshot format version
+const SNAPSHOT_VERSION: u8 = 1;
+
+/// Default LRU cache capacity (number of records)
+pub const DEFAULT_CACHE_CAPACITY: usize = 1000;
+
+/// Configuration for streaming CRDT
+#[derive(Debug, Clone)]
+pub struct StreamingConfig {
+    /// Maximum number of cold records to keep in LRU cache
+    pub cache_capacity: usize,
+    /// Underlying persistence config (for WAL, snapshots, etc.)
+    pub persist_config: PersistConfig,
+}
+
+impl Default for StreamingConfig {
+    fn default() -> Self {
+        Self {
+            cache_capacity: DEFAULT_CACHE_CAPACITY,
+            persist_config: PersistConfig::default(),
+        }
+    }
+}
+
+/// Entry in the snapshot index
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+struct IndexEntry<K> {
+    key: K,
+    offset: u64,
+    length: u32,
+}
+
+
+/// Simple LRU cache implementation
+struct LruCache<K, V> {
+    capacity: usize,
+    map: HashMap<K, V>,
+    order: Vec<K>, // Most recently used at the end
+}
+
+impl<K: Hash + Eq + Clone, V> LruCache<K, V> {
+    fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            map: HashMap::new(),
+            order: Vec::new(),
+        }
+    }
+
+    fn get(&mut self, key: &K) -> Option<&V> {
+        if self.map.contains_key(key) {
+            // Move to end (most recently used)
+            self.order.retain(|k| k != key);
+            self.order.push(key.clone());
+            self.map.get(key)
+        } else {
+            None
+        }
+    }
+
+    fn insert(&mut self, key: K, value: V) {
+        if self.map.contains_key(&key) {
+            // Update existing
+            self.order.retain(|k| k != &key);
+        } else if self.map.len() >= self.capacity {
+            // Evict oldest
+            if let Some(oldest) = self.order.first().cloned() {
+                self.order.remove(0);
+                self.map.remove(&oldest);
+            }
+        }
+        self.order.push(key.clone());
+        self.map.insert(key, value);
+    }
+
+    fn contains_key(&self, key: &K) -> bool {
+        self.map.contains_key(key)
+    }
+}
+
+/// Cold storage backed by an indexed snapshot file
+struct ColdStorage<K, C, V>
+where
+    K: Ord + Hash + Eq + Clone,
+    C: Hash + Eq + Clone,
+    V: Clone,
+{
+    /// The snapshot file (kept open for seeking)
+    file: Option<BufReader<File>>,
+    /// Key -> (offset, length) index
+    index: HashMap<K, (u64, u32)>,
+    /// Tombstones (loaded entirely at startup)
+    tombstones: TombstoneStorage<K>,
+    /// Clock value from snapshot
+    clock_value: u64,
+    /// Phantom data for type parameters
+    _phantom: std::marker::PhantomData<(C, V)>,
+}
+
+impl<K, C, V> ColdStorage<K, C, V>
+where
+    K: Ord + Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+    C: Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+    V: Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+{
+    /// Create empty cold storage (no snapshot file)
+    fn empty() -> Self {
+        Self {
+            file: None,
+            index: HashMap::new(),
+            tombstones: TombstoneStorage::new(),
+            clock_value: 0,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Load cold storage from an indexed snapshot file
+    fn from_file(path: &PathBuf) -> Result<Self, PersistError> {
+        let file = File::open(path)?;
+        let mut reader = BufReader::new(file);
+
+        // Read and verify magic
+        let mut magic = [0u8; 4];
+        reader.read_exact(&mut magic)?;
+        if &magic != SNAPSHOT_MAGIC {
+            return Err(PersistError::InvalidDirectory(
+                "Invalid snapshot magic bytes".to_string(),
+            ));
+        }
+
+        // Read version and flags
+        let mut version_flags = [0u8; 2];
+        reader.read_exact(&mut version_flags)?;
+        let version = version_flags[0];
+        if version != SNAPSHOT_VERSION {
+            return Err(PersistError::InvalidDirectory(format!(
+                "Unsupported snapshot version: {}",
+                version
+            )));
+        }
+        // flags[1] reserved for future use
+
+        // Read header fields
+        let mut header_buf = [0u8; 48]; // 6 * u64
+        reader.read_exact(&mut header_buf)?;
+
+        let node_id = u64::from_le_bytes(header_buf[0..8].try_into().unwrap());
+        let clock_value = u64::from_le_bytes(header_buf[8..16].try_into().unwrap());
+        let record_count = u64::from_le_bytes(header_buf[16..24].try_into().unwrap());
+        let tombstone_count = u64::from_le_bytes(header_buf[24..32].try_into().unwrap());
+        let index_offset = u64::from_le_bytes(header_buf[32..40].try_into().unwrap());
+        let tombstones_offset = u64::from_le_bytes(header_buf[40..48].try_into().unwrap());
+
+        let _ = (node_id, record_count, tombstone_count); // Silence unused warnings
+
+        // Load index from end of file
+        reader.seek(SeekFrom::Start(index_offset))?;
+        let index_entries: Vec<IndexEntry<K>> = rmp_serde::from_read(&mut reader)
+            .map_err(PersistError::MsgpackDecode)?;
+
+        let index: HashMap<K, (u64, u32)> = index_entries
+            .into_iter()
+            .map(|e| (e.key, (e.offset, e.length)))
+            .collect();
+
+        // Load tombstones
+        reader.seek(SeekFrom::Start(tombstones_offset))?;
+        let tombstone_map: HashMap<K, TombstoneInfo> = rmp_serde::from_read(&mut reader)
+            .map_err(PersistError::MsgpackDecode)?;
+
+        let mut tombstones = TombstoneStorage::new();
+        for (key, info) in tombstone_map {
+            tombstones.insert_or_assign(key, info);
+        }
+
+        // Reopen file for record access
+        let file = File::open(path)?;
+        let reader = BufReader::new(file);
+
+        Ok(Self {
+            file: Some(reader),
+            index,
+            tombstones,
+            clock_value,
+            _phantom: std::marker::PhantomData,
+        })
+    }
+
+    /// Load a single record from disk
+    fn load_record(&mut self, key: &K) -> Result<Option<Record<C, V>>, PersistError> {
+        let (offset, length) = match self.index.get(key) {
+            Some(&(o, l)) => (o, l),
+            None => return Ok(None),
+        };
+
+        let reader = match &mut self.file {
+            Some(r) => r,
+            None => return Ok(None),
+        };
+
+        reader.seek(SeekFrom::Start(offset))?;
+
+        let mut buffer = vec![0u8; length as usize];
+        reader.read_exact(&mut buffer)?;
+
+        let record: Record<C, V> =
+            rmp_serde::from_slice(&buffer).map_err(PersistError::MsgpackDecode)?;
+
+        Ok(Some(record))
+    }
+
+    /// Check if a key exists in cold storage
+    fn contains_key(&self, key: &K) -> bool {
+        self.index.contains_key(key)
+    }
+
+    /// Check if a record is tombstoned
+    fn is_tombstoned(&self, key: &K) -> bool {
+        self.tombstones.find(key).is_some()
+    }
+
+    /// Get tombstone info
+    #[allow(dead_code)]
+    fn get_tombstone(&self, key: &K) -> Option<TombstoneInfo> {
+        self.tombstones.find(key)
+    }
+
+    /// Get all keys in cold storage
+    fn keys(&self) -> impl Iterator<Item = &K> {
+        self.index.keys()
+    }
+
+    /// Get number of records in cold storage
+    fn len(&self) -> usize {
+        self.index.len()
+    }
+}
+
+/// A streaming CRDT that loads records on-demand from disk.
+///
+/// This is designed for datasets too large to fit in memory. Recent changes
+/// are kept in a hot in-memory CRDT, while older data is loaded from an
+/// indexed snapshot file on-demand.
+pub struct StreamingCRDT<K, C, V>
+where
+    K: Ord + Hash + Eq + Clone,
+    C: Hash + Eq + Clone,
+    V: Clone,
+{
+    /// Hot tier: recent changes (always in memory)
+    hot: CRDT<K, C, V>,
+    /// Keys that exist in hot tier (for quick membership check)
+    hot_keys: HashSet<K>,
+    /// Keys that have been tombstoned in hot tier
+    hot_tombstones: HashSet<K>,
+
+    /// Cold tier: on-disk storage with index
+    cold: ColdStorage<K, C, V>,
+    /// LRU cache for cold records
+    cache: LruCache<K, Record<C, V>>,
+
+    /// WAL writer for persistence
+    wal: WalWriter<K, C, V>,
+    /// Configuration
+    config: StreamingConfig,
+    /// Base directory for files
+    base_dir: PathBuf,
+
+    /// Changes since last snapshot
+    changes_since_snapshot: usize,
+    /// Current snapshot version
+    snapshot_version: u64,
+
+    /// Hooks
+    post_hooks: Vec<Box<dyn PostOpHook<K, C, V>>>,
+    snapshot_hooks: Vec<Box<dyn SnapshotHook>>,
+    wal_segment_hooks: Vec<Box<dyn WalSegmentHook>>,
+
+    /// Batch collector for network broadcasting
+    batch: Vec<Change<K, C, V>>,
+    /// Last snapshot time
+    last_snapshot_time: std::time::Instant,
+}
+
+impl<K, C, V> StreamingCRDT<K, C, V>
+where
+    K: Ord + Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+    C: Ord + Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+    V: Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+{
+    /// Opens or creates a streaming CRDT at the specified path.
+    ///
+    /// If an indexed snapshot exists, it's opened for lazy loading.
+    /// Otherwise, attempts to migrate from a regular snapshot.
+    pub fn open(
+        base_dir: PathBuf,
+        node_id: NodeId,
+        config: StreamingConfig,
+    ) -> Result<Self, PersistError> {
+        std::fs::create_dir_all(&base_dir)?;
+
+        // Look for indexed snapshot
+        let indexed_snapshot = Self::find_indexed_snapshot(&base_dir)?;
+
+        let (cold, clock_value) = if let Some(path) = indexed_snapshot {
+            let cold = ColdStorage::from_file(&path)?;
+            let clock = cold.clock_value;
+            (cold, clock)
+        } else {
+            // Try to migrate from regular snapshot
+            let migrated = Self::migrate_from_regular_snapshot(&base_dir, node_id)?;
+            if let Some((cold, clock)) = migrated {
+                (cold, clock)
+            } else {
+                (ColdStorage::empty(), 0)
+            }
+        };
+
+        // Create hot CRDT with clock synced to cold
+        let mut hot = CRDT::new(node_id, None);
+        if clock_value > 0 {
+            // Sync hot clock to cold
+            hot.get_clock_mut().set_time(clock_value);
+        }
+
+        // Create WAL writer
+        let wal = WalWriter::new(base_dir.clone())?;
+
+        // Replay WAL on top of cold storage
+        let mut streaming = Self {
+            hot,
+            hot_keys: HashSet::new(),
+            hot_tombstones: HashSet::new(),
+            cold,
+            cache: LruCache::new(config.cache_capacity),
+            wal,
+            config,
+            base_dir,
+            changes_since_snapshot: 0,
+            snapshot_version: 0,
+            post_hooks: Vec::new(),
+            snapshot_hooks: Vec::new(),
+            wal_segment_hooks: Vec::new(),
+            batch: Vec::new(),
+            last_snapshot_time: std::time::Instant::now(),
+        };
+
+        streaming.replay_wal()?;
+
+        Ok(streaming)
+    }
+
+    /// Find the most recent indexed snapshot
+    fn find_indexed_snapshot(base_dir: &PathBuf) -> Result<Option<PathBuf>, PersistError> {
+        let mut snapshots: Vec<(u64, PathBuf)> = Vec::new();
+
+        if let Ok(entries) = std::fs::read_dir(base_dir) {
+            for entry in entries.flatten() {
+                let filename = entry.file_name();
+                let filename_str = filename.to_string_lossy();
+
+                // Look for indexed snapshots: snapshot_indexed_NNNNNN.bin
+                if filename_str.starts_with("snapshot_indexed_")
+                    && filename_str.ends_with(".bin")
+                {
+                    if let Some(version_str) = filename_str
+                        .strip_prefix("snapshot_indexed_")
+                        .and_then(|s| s.strip_suffix(".bin"))
+                    {
+                        if let Ok(version) = version_str.parse::<u64>() {
+                            snapshots.push((version, entry.path()));
+                        }
+                    }
+                }
+            }
+        }
+
+        snapshots.sort_by_key(|(v, _)| *v);
+        Ok(snapshots.last().map(|(_, p)| p.clone()))
+    }
+
+    /// Migrate from a regular PersistedCRDT snapshot to indexed format
+    fn migrate_from_regular_snapshot(
+        base_dir: &PathBuf,
+        node_id: NodeId,
+    ) -> Result<Option<(ColdStorage<K, C, V>, u64)>, PersistError> {
+        // Look for existing MessagePack snapshots
+        let mut snapshots: Vec<(u64, PathBuf)> = Vec::new();
+
+        if let Ok(entries) = std::fs::read_dir(base_dir) {
+            for entry in entries.flatten() {
+                let filename = entry.file_name();
+                let filename_str = filename.to_string_lossy();
+
+                if filename_str.starts_with("snapshot_full_")
+                    && filename_str.ends_with(".msgpack")
+                {
+                    if let Some(version_str) = filename_str
+                        .strip_prefix("snapshot_full_")
+                        .and_then(|s| s.strip_suffix(".msgpack"))
+                    {
+                        if let Ok(version) = version_str.parse::<u64>() {
+                            snapshots.push((version, entry.path()));
+                        }
+                    }
+                }
+            }
+        }
+
+        if snapshots.is_empty() {
+            return Ok(None);
+        }
+
+        snapshots.sort_by_key(|(v, _)| *v);
+        let (version, path) = snapshots.last().unwrap();
+
+        // Load the regular snapshot
+        let bytes = std::fs::read(path)?;
+
+        // Decompress if needed
+        #[cfg(feature = "compression")]
+        let bytes = if bytes.len() >= 4 && &bytes[0..4] == b"\x28\xb5\x2f\xfd" {
+            zstd::decode_all(&bytes[..]).map_err(PersistError::Compression)?
+        } else {
+            bytes
+        };
+
+        #[cfg(not(feature = "compression"))]
+        let bytes = bytes;
+
+        // Parse header
+        if bytes.len() < 4 {
+            return Ok(None);
+        }
+
+        let metadata_len = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
+        if bytes.len() < 4 + metadata_len {
+            return Ok(None);
+        }
+
+        let crdt_bytes = &bytes[4 + metadata_len..];
+        let crdt: CRDT<K, C, V> =
+            CRDT::from_msgpack_bytes(crdt_bytes).map_err(PersistError::MsgpackDecode)?;
+
+        let clock_value = crdt.get_clock().current_time();
+
+        // Create indexed snapshot from the loaded CRDT
+        let indexed_path = base_dir.join(format!("snapshot_indexed_{:06}.bin", version));
+        Self::create_indexed_snapshot_from_crdt(&crdt, node_id, &indexed_path)?;
+
+        // Load the new indexed snapshot
+        let cold = ColdStorage::from_file(&indexed_path)?;
+
+        Ok(Some((cold, clock_value)))
+    }
+
+    /// Create an indexed snapshot from a CRDT
+    fn create_indexed_snapshot_from_crdt(
+        crdt: &CRDT<K, C, V>,
+        node_id: NodeId,
+        path: &PathBuf,
+    ) -> Result<(), PersistError> {
+        let file = File::create(path)?;
+        let mut writer = BufWriter::new(file);
+
+        // Write magic and version
+        writer.write_all(SNAPSHOT_MAGIC)?;
+        writer.write_all(&[SNAPSHOT_VERSION, 0])?; // version, flags
+
+        // Placeholder for header (we'll seek back and write it)
+        let header_pos = writer.stream_position()?;
+        let placeholder = [0u8; 48];
+        writer.write_all(&placeholder)?;
+
+        // Write records and build index
+        let mut index_entries: Vec<IndexEntry<K>> = Vec::new();
+        let records_start = writer.stream_position()?;
+
+        for (key, record) in crdt.get_data().iter() {
+            let offset = writer.stream_position()?;
+            let record_bytes =
+                rmp_serde::to_vec(record).map_err(PersistError::MsgpackEncode)?;
+            writer.write_all(&record_bytes)?;
+
+            index_entries.push(IndexEntry {
+                key: key.clone(),
+                offset,
+                length: record_bytes.len() as u32,
+            });
+        }
+
+        // Write tombstones section
+        let tombstones_offset = writer.stream_position()?;
+        let tombstone_map: HashMap<K, TombstoneInfo> = crdt
+            .get_tombstones()
+            .iter()
+            .map(|(k, v)| (k.clone(), *v))
+            .collect();
+        let tombstone_bytes =
+            rmp_serde::to_vec(&tombstone_map).map_err(PersistError::MsgpackEncode)?;
+        writer.write_all(&tombstone_bytes)?;
+
+        // Write index section
+        let index_offset = writer.stream_position()?;
+        let index_bytes =
+            rmp_serde::to_vec(&index_entries).map_err(PersistError::MsgpackEncode)?;
+        writer.write_all(&index_bytes)?;
+
+        // Write header
+        writer.seek(SeekFrom::Start(header_pos))?;
+        writer.write_all(&node_id.to_le_bytes())?;
+        writer.write_all(&crdt.get_clock().current_time().to_le_bytes())?;
+        writer.write_all(&(index_entries.len() as u64).to_le_bytes())?;
+        writer.write_all(&(tombstone_map.len() as u64).to_le_bytes())?;
+        writer.write_all(&index_offset.to_le_bytes())?;
+        writer.write_all(&tombstones_offset.to_le_bytes())?;
+
+        writer.flush()?;
+        writer.get_ref().sync_all()?;
+
+        let _ = records_start; // Silence unused warning
+
+        Ok(())
+    }
+
+    /// Replay WAL files on top of current state
+    fn replay_wal(&mut self) -> Result<(), PersistError> {
+        let mut wal_files: Vec<_> = std::fs::read_dir(&self.base_dir)?
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                let name = e.file_name().to_string_lossy().to_string();
+                name.starts_with("wal_") && name.ends_with(".bin")
+            })
+            .collect();
+
+        wal_files.sort_by_key(|e| {
+            e.file_name()
+                .to_string_lossy()
+                .strip_prefix("wal_")
+                .and_then(|s| s.strip_suffix(".bin"))
+                .and_then(|n| n.parse::<u64>().ok())
+                .unwrap_or(0)
+        });
+
+        for entry in wal_files {
+            let changes: Vec<Change<K, C, V>> = super::wal::read_wal_file(&entry.path())?;
+            for change in &changes {
+                // Apply to hot tier
+                self.hot_keys.insert(change.record_id.clone());
+                if change.col_name.is_none() {
+                    self.hot_tombstones.insert(change.record_id.clone());
+                }
+            }
+            // Merge the changes
+            self.hot.merge_changes(changes, &DefaultMergeRule);
+            self.changes_since_snapshot += 1;
+        }
+
+        Ok(())
+    }
+
+    /// Get a record, checking hot tier first, then cache, then cold storage
+    pub fn get_record(&mut self, key: &K) -> Result<Option<Record<C, V>>, PersistError> {
+        // 1. Check hot tier first (most recent)
+        if self.hot_keys.contains(key) {
+            if let Some(record) = self.hot.get_record(key) {
+                return Ok(Some(record.clone()));
+            }
+            // Key is in hot but record was deleted
+            if self.hot_tombstones.contains(key) {
+                return Ok(None);
+            }
+        }
+
+        // 2. Check if tombstoned (hot or cold)
+        if self.hot_tombstones.contains(key) || self.cold.is_tombstoned(key) {
+            return Ok(None);
+        }
+
+        // 3. Check LRU cache
+        if let Some(record) = self.cache.get(key) {
+            return Ok(Some(record.clone()));
+        }
+
+        // 4. Load from cold storage
+        if let Some(record) = self.cold.load_record(key)? {
+            self.cache.insert(key.clone(), record.clone());
+            return Ok(Some(record));
+        }
+
+        Ok(None)
+    }
+
+    /// Check if a record exists (without loading full record)
+    pub fn contains_key(&self, key: &K) -> bool {
+        if self.hot_tombstones.contains(key) || self.cold.is_tombstoned(key) {
+            return false;
+        }
+        self.hot_keys.contains(key) || self.cache.contains_key(key) || self.cold.contains_key(key)
+    }
+
+    /// Check if a record is tombstoned
+    pub fn is_tombstoned(&self, key: &K) -> bool {
+        self.hot_tombstones.contains(key) || self.cold.is_tombstoned(key)
+    }
+
+    /// Insert or update a record
+    pub fn insert_or_update<I>(
+        &mut self,
+        record_id: &K,
+        fields: I,
+    ) -> Result<Vec<Change<K, C, V>>, PersistError>
+    where
+        I: IntoIterator<Item = (C, V)>,
+    {
+        // Check tombstones
+        if self.is_tombstoned(record_id) {
+            return Ok(Vec::new());
+        }
+
+        // If record exists in cold but not hot, load it first
+        if !self.hot_keys.contains(record_id) && self.cold.contains_key(record_id) {
+            if let Some(cold_record) = self.cold.load_record(record_id)? {
+                // Merge cold record into hot
+                self.merge_cold_record_to_hot(record_id, cold_record);
+            }
+        }
+
+        // Apply to hot tier
+        let changes = self.hot.insert_or_update(record_id, fields);
+        self.hot_keys.insert(record_id.clone());
+
+        // Persist
+        self.persist_and_notify(&changes)?;
+
+        Ok(changes)
+    }
+
+    /// Delete a record
+    pub fn delete_record(&mut self, record_id: &K) -> Result<Option<Change<K, C, V>>, PersistError> {
+        if self.is_tombstoned(record_id) {
+            return Ok(None);
+        }
+
+        let change = self.hot.delete_record(record_id);
+        if let Some(ref c) = change {
+            self.hot_tombstones.insert(record_id.clone());
+            self.persist_and_notify(std::slice::from_ref(c))?;
+        }
+
+        Ok(change)
+    }
+
+    /// Merge changes from remote nodes
+    pub fn merge_changes(
+        &mut self,
+        changes: Vec<Change<K, C, V>>,
+    ) -> Result<Vec<Change<K, C, V>>, PersistError> {
+        // Load any cold records that are being updated
+        for change in &changes {
+            if !self.hot_keys.contains(&change.record_id)
+                && self.cold.contains_key(&change.record_id)
+            {
+                if let Some(cold_record) = self.cold.load_record(&change.record_id)? {
+                    self.merge_cold_record_to_hot(&change.record_id, cold_record);
+                }
+            }
+        }
+
+        // Apply to hot tier
+        let accepted = self.hot.merge_changes(changes, &DefaultMergeRule);
+
+        // Track keys
+        for change in &accepted {
+            self.hot_keys.insert(change.record_id.clone());
+            if change.col_name.is_none() {
+                self.hot_tombstones.insert(change.record_id.clone());
+            }
+        }
+
+        // Persist
+        self.persist_and_notify(&accepted)?;
+
+        Ok(accepted)
+    }
+
+    /// Get changes since a version (for sync)
+    pub fn get_changes_since(&mut self, last_db_version: u64) -> Result<Vec<Change<K, C, V>>, PersistError> {
+        // Hot tier changes
+        let mut changes = self.hot.get_changes_since(last_db_version);
+
+        // For cold records not in hot, we'd need to scan - but typically
+        // get_changes_since is called for recent changes which are in hot
+        // This is a trade-off for streaming: old cold changes require full scan
+
+        // Sort and dedupe
+        CRDT::compress_changes(&mut changes);
+
+        Ok(changes)
+    }
+
+    /// Create an indexed snapshot of current state
+    pub fn create_indexed_snapshot(&mut self) -> Result<PathBuf, PersistError> {
+        // Merge hot into a temporary full CRDT for snapshot
+        let mut full_crdt: CRDT<K, C, V> = CRDT::new(self.hot.node_id, None);
+
+        // First, load all cold records
+        for key in self.cold.keys().cloned().collect::<Vec<_>>() {
+            if !self.hot_tombstones.contains(&key) {
+                if let Some(record) = self.cold.load_record(&key)? {
+                    // Convert record to changes and merge
+                    let changes = self.record_to_changes(&key, &record);
+                    full_crdt.merge_changes(changes, &DefaultMergeRule);
+                }
+            }
+        }
+
+        // Apply cold tombstones
+        for (key, info) in self.cold.tombstones.iter() {
+            full_crdt.merge_changes(
+                vec![Change::new(
+                    key.clone(),
+                    None,
+                    None,
+                    u64::MAX,
+                    info.db_version,
+                    info.node_id,
+                    info.local_db_version,
+                    0,
+                )],
+                &DefaultMergeRule,
+            );
+        }
+
+        // Merge hot tier on top
+        let hot_changes = self.hot.get_changes_since(0);
+        full_crdt.merge_changes(hot_changes, &DefaultMergeRule);
+
+        // Create indexed snapshot
+        self.snapshot_version += 1;
+        let snapshot_path = self.base_dir.join(format!(
+            "snapshot_indexed_{:06}.bin",
+            self.snapshot_version
+        ));
+
+        Self::create_indexed_snapshot_from_crdt(&full_crdt, self.hot.node_id, &snapshot_path)?;
+
+        // Reload cold storage from new snapshot
+        self.cold = ColdStorage::from_file(&snapshot_path)?;
+
+        // Clear hot tier
+        self.hot = CRDT::new(self.hot.node_id, None);
+        self.hot.get_clock_mut().set_time(self.cold.clock_value);
+        self.hot_keys.clear();
+        self.hot_tombstones.clear();
+        self.cache = LruCache::new(self.config.cache_capacity);
+
+        // Rotate WAL and delete old segments (snapshot has all data)
+        let _ = self.wal.rotate(&self.base_dir, &self.wal_segment_hooks)?;
+        self.cleanup_old_wal_files()?;
+
+        // Reset counters
+        self.changes_since_snapshot = 0;
+        self.last_snapshot_time = std::time::Instant::now();
+
+        // Call hooks
+        let db_version = self.cold.clock_value;
+        for hook in &self.snapshot_hooks {
+            hook.on_snapshot(&snapshot_path, db_version);
+        }
+
+        Ok(snapshot_path)
+    }
+
+    /// Get the batch of changes for network broadcasting
+    pub fn take_batch(&mut self) -> Vec<Change<K, C, V>> {
+        std::mem::take(&mut self.batch)
+    }
+
+    /// Add a post-operation hook
+    pub fn add_post_hook(&mut self, hook: Box<dyn PostOpHook<K, C, V>>) {
+        self.post_hooks.push(hook);
+    }
+
+    /// Add a snapshot hook
+    pub fn add_snapshot_hook(&mut self, hook: Box<dyn SnapshotHook>) {
+        self.snapshot_hooks.push(hook);
+    }
+
+    /// Add a WAL segment hook
+    pub fn add_wal_segment_hook(&mut self, hook: Box<dyn WalSegmentHook>) {
+        self.wal_segment_hooks.push(hook);
+    }
+
+    /// Get number of records in hot tier
+    pub fn hot_record_count(&self) -> usize {
+        self.hot_keys.len()
+    }
+
+    /// Get number of records in cold storage
+    pub fn cold_record_count(&self) -> usize {
+        self.cold.len()
+    }
+
+    /// Get current logical clock value
+    pub fn get_clock_time(&self) -> u64 {
+        self.hot.get_clock().current_time()
+    }
+
+    // Helper methods
+
+    fn merge_cold_record_to_hot(&mut self, key: &K, record: Record<C, V>) {
+        let changes = self.record_to_changes(key, &record);
+        self.hot.merge_changes(changes, &DefaultMergeRule);
+        self.hot_keys.insert(key.clone());
+    }
+
+    fn record_to_changes(&self, key: &K, record: &Record<C, V>) -> Vec<Change<K, C, V>> {
+        let mut changes = Vec::new();
+        for (col_name, value) in &record.fields {
+            if let Some(col_ver) = record.column_versions.get(col_name) {
+                changes.push(Change::new(
+                    key.clone(),
+                    Some(col_name.clone()),
+                    Some(value.clone()),
+                    col_ver.col_version,
+                    col_ver.db_version,
+                    col_ver.node_id,
+                    col_ver.local_db_version,
+                    0,
+                ));
+            }
+        }
+        changes
+    }
+
+    /// Delete all WAL files except the current one
+    fn cleanup_old_wal_files(&self) -> Result<(), PersistError> {
+        let current_segment = self.wal.current_segment();
+
+        if let Ok(entries) = std::fs::read_dir(&self.base_dir) {
+            for entry in entries.flatten() {
+                let filename = entry.file_name();
+                let filename_str = filename.to_string_lossy();
+
+                if filename_str.starts_with("wal_") && filename_str.ends_with(".bin") {
+                    // Parse segment number
+                    if let Some(num_str) = filename_str
+                        .strip_prefix("wal_")
+                        .and_then(|s| s.strip_suffix(".bin"))
+                    {
+                        if let Ok(segment_num) = num_str.parse::<u64>() {
+                            // Keep current segment, delete others
+                            if segment_num < current_segment {
+                                let _ = std::fs::remove_file(entry.path());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn persist_and_notify(&mut self, changes: &[Change<K, C, V>]) -> Result<(), PersistError> {
+        if changes.is_empty() {
+            return Ok(());
+        }
+
+        // Append to WAL
+        self.wal.append(changes)?;
+        self.changes_since_snapshot += changes.len();
+
+        // Add to batch
+        self.batch.extend_from_slice(changes);
+
+        // Call post hooks
+        for hook in &self.post_hooks {
+            hook.after_op(changes);
+        }
+
+        // Check auto-snapshot
+        self.check_auto_snapshot()?;
+
+        Ok(())
+    }
+
+    fn check_auto_snapshot(&mut self) -> Result<(), PersistError> {
+        let should_snapshot = self.changes_since_snapshot
+            >= self.config.persist_config.snapshot_threshold
+            || self
+                .config
+                .persist_config
+                .snapshot_interval_secs
+                .map(|i| self.last_snapshot_time.elapsed().as_secs() >= i)
+                .unwrap_or(false);
+
+        if should_snapshot {
+            self.create_indexed_snapshot()?;
+        }
+
+        Ok(())
+    }
+}
+
+// Need to add get_clock_mut and get_tombstones to CRDT - let's do that via a trait extension
+// For now, we'll work around it
+
+impl<K: Ord + Hash + Eq + Clone, C: Hash + Eq + Clone, V: Clone> CRDT<K, C, V> {
+    /// Mutable access to the logical clock (for internal use)
+    pub(crate) fn get_clock_mut(&mut self) -> &mut LogicalClock {
+        &mut self.clock
+    }
+
+    /// Access to tombstones (for internal use)
+    pub(crate) fn get_tombstones(&self) -> &TombstoneStorage<K> {
+        &self.tombstones
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_streaming_basic_operations() {
+        let temp_dir = TempDir::new().unwrap();
+        let base_dir = temp_dir.path().to_path_buf();
+
+        let mut crdt = StreamingCRDT::<String, String, String>::open(
+            base_dir.clone(),
+            1,
+            StreamingConfig::default(),
+        )
+        .unwrap();
+
+        // Insert
+        let changes = crdt
+            .insert_or_update(
+                &"key1".to_string(),
+                vec![("field1".to_string(), "value1".to_string())],
+            )
+            .unwrap();
+
+        assert_eq!(changes.len(), 1);
+
+        // Get
+        let record = crdt.get_record(&"key1".to_string()).unwrap();
+        assert!(record.is_some());
+        assert_eq!(
+            record.unwrap().fields.get("field1").unwrap(),
+            "value1"
+        );
+
+        // Delete
+        let delete = crdt.delete_record(&"key1".to_string()).unwrap();
+        assert!(delete.is_some());
+
+        // Get after delete
+        let record = crdt.get_record(&"key1".to_string()).unwrap();
+        assert!(record.is_none());
+    }
+
+    #[test]
+    fn test_streaming_snapshot_and_reload() {
+        let temp_dir = TempDir::new().unwrap();
+        let base_dir = temp_dir.path().to_path_buf();
+
+        // Create and populate
+        {
+            let mut crdt = StreamingCRDT::<String, String, String>::open(
+                base_dir.clone(),
+                1,
+                StreamingConfig::default(),
+            )
+            .unwrap();
+
+            for i in 0..100 {
+                crdt.insert_or_update(
+                    &format!("key{}", i),
+                    vec![(format!("field{}", i), format!("value{}", i))],
+                )
+                .unwrap();
+            }
+
+            // Create indexed snapshot
+            crdt.create_indexed_snapshot().unwrap();
+        }
+
+        // Reopen and verify
+        {
+            let mut crdt = StreamingCRDT::<String, String, String>::open(
+                base_dir.clone(),
+                1,
+                StreamingConfig::default(),
+            )
+            .unwrap();
+
+            // Records should be in cold storage
+            assert_eq!(crdt.cold_record_count(), 100);
+            assert_eq!(crdt.hot_record_count(), 0);
+
+            // Access should work (lazy load)
+            let record = crdt.get_record(&"key50".to_string()).unwrap();
+            assert!(record.is_some());
+            assert_eq!(
+                record.unwrap().fields.get("field50").unwrap(),
+                "value50"
+            );
+        }
+    }
+
+    #[test]
+    fn test_streaming_hot_cold_merge() {
+        let temp_dir = TempDir::new().unwrap();
+        let base_dir = temp_dir.path().to_path_buf();
+
+        // Create initial data and snapshot
+        {
+            let mut crdt = StreamingCRDT::<String, String, String>::open(
+                base_dir.clone(),
+                1,
+                StreamingConfig::default(),
+            )
+            .unwrap();
+
+            crdt.insert_or_update(
+                &"key1".to_string(),
+                vec![
+                    ("field1".to_string(), "cold_value".to_string()),
+                    ("field2".to_string(), "unchanged".to_string()),
+                ],
+            )
+            .unwrap();
+
+            crdt.create_indexed_snapshot().unwrap();
+        }
+
+        // Reopen and modify
+        {
+            let mut crdt = StreamingCRDT::<String, String, String>::open(
+                base_dir.clone(),
+                1,
+                StreamingConfig::default(),
+            )
+            .unwrap();
+
+            // Update one field (should load cold record first)
+            crdt.insert_or_update(
+                &"key1".to_string(),
+                vec![("field1".to_string(), "hot_value".to_string())],
+            )
+            .unwrap();
+
+            // Verify merged result
+            let record = crdt.get_record(&"key1".to_string()).unwrap().unwrap();
+            assert_eq!(record.fields.get("field1").unwrap(), "hot_value");
+            assert_eq!(record.fields.get("field2").unwrap(), "unchanged");
+        }
+    }
+}

--- a/src/persist/streaming.rs
+++ b/src/persist/streaming.rs
@@ -640,42 +640,26 @@ where
     }
   }
 
-  /// Migrate from a regular PersistedCRDT snapshot to indexed format
+  /// Migrate from a regular PersistedCRDT snapshot to indexed format.
+  ///
+  /// Handles both full and incremental snapshots: loads the latest full snapshot,
+  /// applies any incremental snapshots that build on it (matching PersistedCRDT
+  /// recovery logic), then converts to indexed format.
   fn migrate_from_regular_snapshot(
     base_dir: &PathBuf,
     node_id: NodeId,
   ) -> MigrationResult<K, C, V> {
-    // Look for existing MessagePack snapshots
-    let mut snapshots: Vec<(u64, PathBuf)> = Vec::new();
+    // Use PersistedCRDT's snapshot discovery to find full + incremental snapshots
+    let (latest_full, incrementals) =
+      super::PersistedCRDT::<K, C, V>::discover_snapshots(base_dir)?;
 
-    if let Ok(entries) = std::fs::read_dir(base_dir) {
-      for entry in entries.flatten() {
-        let filename = entry.file_name();
-        let filename_str = filename.to_string_lossy();
+    let (full_path, full_version) = match latest_full {
+      Some(v) => v,
+      None => return Ok(None),
+    };
 
-        if filename_str.starts_with("snapshot_full_") && filename_str.ends_with(".msgpack") {
-          if let Some(version_str) = filename_str
-            .strip_prefix("snapshot_full_")
-            .and_then(|s| s.strip_suffix(".msgpack"))
-          {
-            if let Ok(version) = version_str.parse::<u64>() {
-              snapshots.push((version, entry.path()));
-            }
-          }
-        }
-      }
-    }
-
-    if snapshots.is_empty() {
-      return Ok(None);
-    }
-
-    snapshots.sort_by_key(|(v, _)| *v);
-    let (version, path) = snapshots.last().unwrap();
-    let version = *version;
-
-    // Load the regular snapshot
-    let bytes = std::fs::read(path)?;
+    // Load the full snapshot
+    let bytes = std::fs::read(&full_path)?;
 
     // Decompress if needed
     #[cfg(feature = "compression")]
@@ -690,7 +674,7 @@ where
       return Err(PersistError::InvalidDirectory(format!(
         "Snapshot file too small to contain header: {} bytes (path: {})",
         bytes.len(),
-        path.display()
+        full_path.display()
       )));
     }
 
@@ -700,15 +684,75 @@ where
         "Snapshot truncated: header says {} bytes metadata but file only has {} bytes after header (path: {})",
         metadata_len,
         bytes.len().saturating_sub(4),
-        path.display()
+        full_path.display()
       )));
     }
 
     let crdt_bytes = &bytes[4 + metadata_len..];
-    let crdt: CRDT<K, C, V> =
+    let mut crdt: CRDT<K, C, V> =
       CRDT::from_msgpack_bytes(crdt_bytes).map_err(PersistError::MsgpackDecode)?;
 
+    // Apply incremental snapshots in order (matching PersistedCRDT recovery logic).
+    // Without this, records stored only in incrementals would be silently lost,
+    // since the WAL only contains changes since the last incremental snapshot.
+    for (incr_path, _) in incrementals {
+      let incr_bytes = std::fs::read(&incr_path)?;
+      let incr_decompressed = {
+        #[cfg(feature = "compression")]
+        {
+          if incr_bytes.len() >= 4 && &incr_bytes[0..4] == b"\x28\xb5\x2f\xfd" {
+            zstd::decode_all(&incr_bytes[..]).map_err(PersistError::Compression)?
+          } else {
+            incr_bytes
+          }
+        }
+        #[cfg(not(feature = "compression"))]
+        {
+          incr_bytes
+        }
+      };
+
+      let incremental: super::IncrementalSnapshot<K, C, V> =
+        rmp_serde::from_slice(&incr_decompressed)?;
+
+      // Convert incremental records to changes and apply
+      let mut changes = Vec::new();
+      for (key, record) in incremental.changed_records {
+        for (col_name, value) in record.fields {
+          if let Some(col_version) = record.column_versions.get(&col_name) {
+            changes.push(Change {
+              record_id: key.clone(),
+              col_name: Some(col_name),
+              value: Some(value),
+              col_version: col_version.col_version,
+              db_version: col_version.db_version,
+              node_id: col_version.node_id,
+              local_db_version: col_version.local_db_version,
+              flags: 0,
+            });
+          }
+        }
+      }
+
+      // Add tombstone changes
+      for (key, tombstone) in incremental.new_tombstones {
+        changes.push(Change {
+          record_id: key,
+          col_name: None,
+          value: None,
+          col_version: 0,
+          db_version: tombstone.db_version,
+          node_id: tombstone.node_id,
+          local_db_version: tombstone.local_db_version,
+          flags: 1,
+        });
+      }
+
+      crdt.merge_changes(changes, &DefaultMergeRule);
+    }
+
     let clock_value = crdt.get_clock().current_time();
+    let version = full_version;
 
     // Create indexed snapshot from the loaded CRDT (with atomic write)
     let indexed_path = base_dir.join(format!("snapshot_indexed_{:06}.bin", version));
@@ -962,16 +1006,27 @@ where
 
     for entry in wal_files {
       let changes: Vec<Change<K, C, V>> = super::wal::read_wal_file(&entry.path())?;
-      for change in &changes {
-        // Track keys for hot tier membership
+
+      // Filter out changes for records that are tombstoned in cold storage.
+      // Without this, WAL entries predating the current snapshot could resurrect
+      // records that were deleted after the WAL was written (zombie resurrection).
+      // This happens when auto_cleanup_wal=false (WAL hooks registered) and old
+      // WAL segments survive across snapshot cycles.
+      let changes: Vec<Change<K, C, V>> = changes
+        .into_iter()
+        .filter(|c| !self.cold.is_tombstoned(&c.record_id))
+        .collect();
+
+      // Merge first, then track only ACCEPTED changes in hot_keys/hot_tombstones.
+      // Tracking before merge would pollute hot_keys with rejected changes, causing
+      // create_streaming_snapshot to skip valid cold records (silent data loss).
+      let accepted = self.hot.merge_changes(changes, &DefaultMergeRule);
+      for change in &accepted {
         self.hot_keys.insert(change.record_id.clone());
         if change.col_name.is_none() {
           self.hot_tombstones.insert(change.record_id.clone());
         }
       }
-      // Merge the changes and count only ACCEPTED changes
-      // (merge_changes may reject some during conflict resolution)
-      let accepted = self.hot.merge_changes(changes, &DefaultMergeRule);
       self.changes_since_snapshot += accepted.len();
     }
 
@@ -1318,16 +1373,17 @@ where
     let cold_compacted = self.cold.tombstones.compact(min_acknowledged_version);
 
     let total = hot_compacted + cold_compacted;
-    if total > 0 {
-      // Force snapshot to persist the compacted state
-      self.create_indexed_snapshot()?;
 
-      // CRITICAL: Delete old WAL segments that contain tombstone records.
-      // Failure to do this causes zombie records to reappear on recovery.
-      // This must be unconditional regardless of auto_cleanup_wal config,
-      // matching PersistedCRDT::compact_tombstones behavior.
-      self.cleanup_old_wal_segments(0, false)?;
-    }
+    // Always create snapshot and clean up WAL unconditionally, matching
+    // PersistedCRDT::compact_tombstones behavior. Even when total==0, this
+    // ensures consistent state and WAL cleanup.
+    self.create_indexed_snapshot()?;
+
+    // CRITICAL: Delete old WAL segments that contain tombstone records.
+    // Failure to do this causes zombie records to reappear on recovery.
+    // Use internal cleanup to unconditionally delete all old segments
+    // regardless of auto_cleanup_wal config.
+    self.cleanup_old_wal_segments_internal()?;
 
     Ok(total)
   }
@@ -2367,12 +2423,12 @@ mod tests {
     assert!(!all.is_empty());
 
     // Excluding node 1 should return nothing
-    let excluding = HashSet::from([1u64]);
+    let excluding = HashSet::from([1 as NodeId]);
     let filtered = crdt.get_changes_since_excluding(0, &excluding).unwrap();
     assert!(filtered.is_empty(), "Should exclude node 1's changes");
 
     // Excluding a different node should return all changes
-    let other = HashSet::from([99u64]);
+    let other = HashSet::from([99 as NodeId]);
     let not_filtered = crdt.get_changes_since_excluding(0, &other).unwrap();
     assert_eq!(not_filtered.len(), all.len());
   }

--- a/src/persist/wal.rs
+++ b/src/persist/wal.rs
@@ -169,6 +169,11 @@ where
     fn segment_path(base_path: &Path, segment: u64) -> PathBuf {
         base_path.join(format!("wal_{:06}.bin", segment))
     }
+
+    /// Returns the current segment number.
+    pub fn current_segment(&self) -> u64 {
+        self.segment_number
+    }
 }
 
 /// Reads all changes from a WAL file.

--- a/src/persist/wal.rs
+++ b/src/persist/wal.rs
@@ -177,6 +177,17 @@ where
   pub fn current_segment(&self) -> u64 {
     self.segment_number
   }
+
+  /// Explicitly flush WAL buffer to OS page cache.
+  ///
+  /// This ensures all pending writes are handed off to the OS (but NOT fsynced to disk).
+  /// Call this before firing hooks to guarantee they see written data.
+  ///
+  /// Note: `append()` already calls flush internally, but this method provides
+  /// explicit control for callers who need to guarantee ordering.
+  pub fn flush(&mut self) -> io::Result<()> {
+    self.current_file.flush()
+  }
 }
 
 /// Reads all changes from a WAL file.

--- a/src/persist/wal.rs
+++ b/src/persist/wal.rs
@@ -23,287 +23,296 @@ use std::path::{Path, PathBuf};
 /// Writer for append-only WAL segments.
 pub struct WalWriter<K, C, V>
 where
-    K: Hash + Eq + Clone,
-    C: Hash + Eq + Clone,
-    V: Clone,
+  K: Hash + Eq + Clone,
+  C: Hash + Eq + Clone,
+  V: Clone,
 {
-    /// Current WAL segment file
-    current_file: BufWriter<File>,
-    /// Current segment number
-    segment_number: u64,
-    /// Base directory path
-    _phantom: std::marker::PhantomData<(K, C, V)>,
+  /// Current WAL segment file
+  current_file: BufWriter<File>,
+  /// Current segment number
+  segment_number: u64,
+  /// Base directory path
+  _phantom: std::marker::PhantomData<(K, C, V)>,
 }
 
 impl<K, C, V> WalWriter<K, C, V>
 where
-    K: Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
-    C: Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
-    V: Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+  K: Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+  C: Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+  V: Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
 {
-    /// Creates a new WAL writer.
-    ///
-    /// Finds the highest existing segment number and continues from there.
-    pub fn new(base_path: PathBuf) -> io::Result<Self> {
-        // Find the highest existing segment number
-        let mut max_segment = 0;
-        if let Ok(entries) = std::fs::read_dir(&base_path) {
-            for entry in entries.flatten() {
-                let filename = entry.file_name();
-                let filename_str = filename.to_string_lossy();
-                if filename_str.starts_with("wal_") && filename_str.ends_with(".bin") {
-                    // Parse segment number from filename (wal_000001.bin)
-                    if let Some(num_str) = filename_str
-                        .strip_prefix("wal_")
-                        .and_then(|s| s.strip_suffix(".bin"))
-                    {
-                        if let Ok(num) = num_str.parse::<u64>() {
-                            max_segment = max_segment.max(num);
-                        }
-                    }
-                }
+  /// Creates a new WAL writer.
+  ///
+  /// Finds the highest existing segment number and continues from there.
+  pub fn new(base_path: PathBuf) -> io::Result<Self> {
+    // Find the highest existing segment number
+    let mut max_segment = 0;
+    if let Ok(entries) = std::fs::read_dir(&base_path) {
+      for entry in entries.flatten() {
+        let filename = entry.file_name();
+        let filename_str = filename.to_string_lossy();
+        if filename_str.starts_with("wal_") && filename_str.ends_with(".bin") {
+          // Parse segment number from filename (wal_000001.bin)
+          if let Some(num_str) = filename_str
+            .strip_prefix("wal_")
+            .and_then(|s| s.strip_suffix(".bin"))
+          {
+            if let Ok(num) = num_str.parse::<u64>() {
+              max_segment = max_segment.max(num);
             }
+          }
         }
-
-        // Start new segment after the highest found
-        let segment_number = max_segment + 1;
-        let wal_path = Self::segment_path(&base_path, segment_number);
-
-        // Open file in append mode
-        let file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(wal_path)?;
-
-        Ok(Self {
-            current_file: BufWriter::new(file),
-            segment_number,
-            _phantom: std::marker::PhantomData,
-        })
+      }
     }
 
-    /// Appends changes to the current WAL segment.
-    ///
-    /// Changes are written immediately but not fsynced (relies on OS buffering).
-    pub fn append(&mut self, changes: &[Change<K, C, V>]) -> io::Result<()> {
-        let config = config::standard();
+    // Start new segment after the highest found
+    let segment_number = max_segment + 1;
+    let wal_path = Self::segment_path(&base_path, segment_number);
 
-        for change in changes {
-            // Serialize and write each change using bincode::serde
-            let bytes = bincode::serde::encode_to_vec(change, config)
-                .map_err(io::Error::other)?;
+    // Open file in append mode
+    let file = OpenOptions::new()
+      .create(true)
+      .append(true)
+      .open(wal_path)?;
 
-            // Write length prefix (for reading back)
-            let len = bytes.len() as u64;
-            self.current_file.write_all(&len.to_le_bytes())?;
+    Ok(Self {
+      current_file: BufWriter::new(file),
+      segment_number,
+      _phantom: std::marker::PhantomData,
+    })
+  }
 
-            // Write the serialized change
-            self.current_file.write_all(&bytes)?;
+  /// Appends changes to the current WAL segment.
+  ///
+  /// Changes are written immediately but not fsynced (relies on OS buffering).
+  pub fn append(&mut self, changes: &[Change<K, C, V>]) -> io::Result<()> {
+    let config = config::standard();
+
+    for change in changes {
+      // Serialize and write each change using bincode::serde
+      let bytes = bincode::serde::encode_to_vec(change, config).map_err(io::Error::other)?;
+
+      // Write length prefix (for reading back)
+      let len = bytes.len() as u64;
+      self.current_file.write_all(&len.to_le_bytes())?;
+
+      // Write the serialized change
+      self.current_file.write_all(&bytes)?;
+    }
+
+    // Flush buffer (but don't fsync)
+    self.current_file.flush()?;
+
+    Ok(())
+  }
+
+  /// Rotates to a new WAL segment, sealing old ones.
+  ///
+  /// Called after snapshot creation. Fsyncs current segment, calls hooks on sealed segments.
+  /// Returns paths of sealed segments. Does NOT delete them - use cleanup_old_wal_segments() after successful upload.
+  pub fn rotate(
+    &mut self,
+    base_path: &Path,
+    hooks: &[Box<dyn super::hooks::WalSegmentHook>],
+  ) -> io::Result<Vec<PathBuf>> {
+    // Flush and fsync current file to ensure data is on disk before hooks fire
+    self.current_file.flush()?;
+    self.current_file.get_ref().sync_all()?;
+
+    // Create new segment file FIRST (before directory reads) to minimize Windows locking issues
+    self.segment_number += 1;
+    let new_wal_path = Self::segment_path(base_path, self.segment_number);
+
+    let new_file = OpenOptions::new()
+      .create(true)
+      .write(true)
+      .truncate(true)
+      .open(&new_wal_path)?;
+
+    // Replace the current BufWriter, dropping the old one and closing the old file handle
+    self.current_file = BufWriter::new(new_file);
+
+    // On Windows, give OS time to release file locks before directory operations
+    // Windows file system operations are asynchronous at kernel level - even after replacing
+    // BufWriter (which drops old file), the handle may not be fully released immediately.
+    // 10ms is typically sufficient, but under heavy load this could still fail.
+    #[cfg(target_os = "windows")]
+    std::thread::sleep(std::time::Duration::from_millis(10));
+
+    // Now collect all sealed WAL segment paths (old file handle is released)
+    let mut sealed_segments = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(base_path) {
+      for entry in entries.flatten() {
+        let filename = entry.file_name();
+        let filename_str = filename.to_string_lossy();
+        if filename_str.starts_with("wal_") && filename_str.ends_with(".bin") {
+          // Don't include the new segment we just created
+          let path = entry.path();
+          if path != new_wal_path {
+            sealed_segments.push(path);
+          }
         }
-
-        // Flush buffer (but don't fsync)
-        self.current_file.flush()?;
-
-        Ok(())
+      }
     }
 
-    /// Rotates to a new WAL segment, sealing old ones.
-    ///
-    /// Called after snapshot creation. Fsyncs current segment, calls hooks on sealed segments.
-    /// Returns paths of sealed segments. Does NOT delete them - use cleanup_old_wal_segments() after successful upload.
-    pub fn rotate(&mut self, base_path: &Path, hooks: &[Box<dyn super::hooks::WalSegmentHook>]) -> io::Result<Vec<PathBuf>> {
-        // Flush and fsync current file to ensure data is on disk before hooks fire
-        self.current_file.flush()?;
-        self.current_file.get_ref().sync_all()?;
-
-        // Create new segment file FIRST (before directory reads) to minimize Windows locking issues
-        self.segment_number += 1;
-        let new_wal_path = Self::segment_path(base_path, self.segment_number);
-
-        let new_file = OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(&new_wal_path)?;
-
-        // Replace the current BufWriter, dropping the old one and closing the old file handle
-        self.current_file = BufWriter::new(new_file);
-
-        // On Windows, give OS time to release file locks before directory operations
-        // Windows file system operations are asynchronous at kernel level - even after replacing
-        // BufWriter (which drops old file), the handle may not be fully released immediately.
-        // 10ms is typically sufficient, but under heavy load this could still fail.
-        #[cfg(target_os = "windows")]
-        std::thread::sleep(std::time::Duration::from_millis(10));
-
-        // Now collect all sealed WAL segment paths (old file handle is released)
-        let mut sealed_segments = Vec::new();
-        if let Ok(entries) = std::fs::read_dir(base_path) {
-            for entry in entries.flatten() {
-                let filename = entry.file_name();
-                let filename_str = filename.to_string_lossy();
-                if filename_str.starts_with("wal_") && filename_str.ends_with(".bin") {
-                    // Don't include the new segment we just created
-                    let path = entry.path();
-                    if path != new_wal_path {
-                        sealed_segments.push(path);
-                    }
-                }
-            }
-        }
-
-        // Call hooks on sealed segments (old file is closed, data is fsynced)
-        for segment_path in &sealed_segments {
-            for hook in hooks {
-                hook.on_wal_sealed(segment_path);
-            }
-        }
-
-        // Return sealed segment paths for tracking
-        // NOTE: Segments are NOT deleted here - caller should use cleanup_old_wal_segments()
-        // after confirming successful upload to avoid data loss if hooks fail
-        Ok(sealed_segments)
+    // Call hooks on sealed segments (old file is closed, data is fsynced)
+    for segment_path in &sealed_segments {
+      for hook in hooks {
+        hook.on_wal_sealed(segment_path);
+      }
     }
 
-    /// Constructs the path for a WAL segment file.
-    fn segment_path(base_path: &Path, segment: u64) -> PathBuf {
-        base_path.join(format!("wal_{:06}.bin", segment))
-    }
+    // Return sealed segment paths for tracking
+    // NOTE: Segments are NOT deleted here - caller should use cleanup_old_wal_segments()
+    // after confirming successful upload to avoid data loss if hooks fail
+    Ok(sealed_segments)
+  }
 
-    /// Returns the current segment number.
-    pub fn current_segment(&self) -> u64 {
-        self.segment_number
-    }
+  /// Constructs the path for a WAL segment file.
+  fn segment_path(base_path: &Path, segment: u64) -> PathBuf {
+    base_path.join(format!("wal_{:06}.bin", segment))
+  }
+
+  /// Returns the current segment number.
+  pub fn current_segment(&self) -> u64 {
+    self.segment_number
+  }
 }
 
 /// Reads all changes from a WAL file.
 pub fn read_wal_file<K, C, V>(path: &Path) -> io::Result<Vec<Change<K, C, V>>>
 where
-    K: Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
-    C: Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
-    V: Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+  K: Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+  C: Hash + Eq + Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
+  V: Clone + serde::Serialize + for<'de> serde::Deserialize<'de>,
 {
-    let file = File::open(path)?;
-    let mut reader = BufReader::new(file);
-    let config = config::standard();
+  let file = File::open(path)?;
+  let mut reader = BufReader::new(file);
+  let config = config::standard();
 
-    let mut changes = Vec::new();
+  let mut changes = Vec::new();
 
-    // Read changes until EOF
-    loop {
-        // Read length prefix
-        let mut len_bytes = [0u8; 8];
-        match reader.read_exact(&mut len_bytes) {
-            Ok(_) => {}
-            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => break,
-            Err(e) => return Err(e),
-        }
-
-        let len = u64::from_le_bytes(len_bytes) as usize;
-
-        // Read the serialized change
-        let mut buffer = vec![0u8; len];
-        reader.read_exact(&mut buffer)?;
-
-        // Deserialize using bincode::serde
-        let change: Change<K, C, V> = bincode::serde::decode_from_slice(&buffer, config)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
-            .0;
-
-        changes.push(change);
+  // Read changes until EOF
+  loop {
+    // Read length prefix
+    let mut len_bytes = [0u8; 8];
+    match reader.read_exact(&mut len_bytes) {
+      Ok(_) => {}
+      Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => break,
+      Err(e) => return Err(e),
     }
 
-    Ok(changes)
+    let len = u64::from_le_bytes(len_bytes) as usize;
+
+    // Read the serialized change
+    let mut buffer = vec![0u8; len];
+    reader.read_exact(&mut buffer)?;
+
+    // Deserialize using bincode::serde
+    let change: Change<K, C, V> = bincode::serde::decode_from_slice(&buffer, config)
+      .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
+      .0;
+
+    changes.push(change);
+  }
+
+  Ok(changes)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::persist::hooks::WalSegmentHook;
-    use crate::Change;
+  use super::*;
+  use crate::persist::hooks::WalSegmentHook;
+  use crate::Change;
 
-    #[test]
-    fn test_wal_write_read() {
-        let temp_dir = std::env::temp_dir().join("crdt_wal_test");
-        let _ = std::fs::remove_dir_all(&temp_dir);
-        std::fs::create_dir_all(&temp_dir).unwrap();
+  #[test]
+  fn test_wal_write_read() {
+    let temp_dir = std::env::temp_dir().join("crdt_wal_test");
+    let _ = std::fs::remove_dir_all(&temp_dir);
+    std::fs::create_dir_all(&temp_dir).unwrap();
 
-        // Create some test changes
-        let changes = vec![
-            Change {
-                record_id: "rec1".to_string(),
-                col_name: Some("field1".to_string()),
-                value: Some("value1".to_string()),
-                col_version: 1,
-                db_version: 1,
-                node_id: 1,
-                local_db_version: 1,
-                flags: 0,
-            },
-            Change {
-                record_id: "rec2".to_string(),
-                col_name: Some("field2".to_string()),
-                value: Some("value2".to_string()),
-                col_version: 1,
-                db_version: 2,
-                node_id: 1,
-                local_db_version: 2,
-                flags: 0,
-            },
-        ];
+    // Create some test changes
+    let changes = vec![
+      Change {
+        record_id: "rec1".to_string(),
+        col_name: Some("field1".to_string()),
+        value: Some("value1".to_string()),
+        col_version: 1,
+        db_version: 1,
+        node_id: 1,
+        local_db_version: 1,
+        flags: 0,
+      },
+      Change {
+        record_id: "rec2".to_string(),
+        col_name: Some("field2".to_string()),
+        value: Some("value2".to_string()),
+        col_version: 1,
+        db_version: 2,
+        node_id: 1,
+        local_db_version: 2,
+        flags: 0,
+      },
+    ];
 
-        // Write changes
-        let mut writer: WalWriter<String, String, String> = WalWriter::new(temp_dir.clone()).unwrap();
-        writer.append(&changes).unwrap();
+    // Write changes
+    let mut writer: WalWriter<String, String, String> = WalWriter::new(temp_dir.clone()).unwrap();
+    writer.append(&changes).unwrap();
 
-        // Read them back
-        let wal_path = temp_dir.join("wal_000001.bin");
-        let read_changes: Vec<Change<String, String, String>> = read_wal_file(&wal_path).unwrap();
+    // Read them back
+    let wal_path = temp_dir.join("wal_000001.bin");
+    let read_changes: Vec<Change<String, String, String>> = read_wal_file(&wal_path).unwrap();
 
-        assert_eq!(read_changes.len(), 2);
-        assert_eq!(read_changes[0].record_id, "rec1");
-        assert_eq!(read_changes[1].record_id, "rec2");
+    assert_eq!(read_changes.len(), 2);
+    assert_eq!(read_changes[0].record_id, "rec1");
+    assert_eq!(read_changes[1].record_id, "rec2");
 
-        // Cleanup
-        let _ = std::fs::remove_dir_all(&temp_dir);
-    }
+    // Cleanup
+    let _ = std::fs::remove_dir_all(&temp_dir);
+  }
 
-    #[test]
-    fn test_wal_rotation() {
-        let temp_dir = std::env::temp_dir().join("crdt_wal_rotation_test");
-        let _ = std::fs::remove_dir_all(&temp_dir);
-        std::fs::create_dir_all(&temp_dir).unwrap();
+  #[test]
+  fn test_wal_rotation() {
+    let temp_dir = std::env::temp_dir().join("crdt_wal_rotation_test");
+    let _ = std::fs::remove_dir_all(&temp_dir);
+    std::fs::create_dir_all(&temp_dir).unwrap();
 
-        let changes = vec![Change {
-            record_id: "rec1".to_string(),
-            col_name: Some("field1".to_string()),
-            value: Some("value1".to_string()),
-            col_version: 1,
-            db_version: 1,
-            node_id: 1,
-            local_db_version: 1,
-            flags: 0,
-        }];
+    let changes = vec![Change {
+      record_id: "rec1".to_string(),
+      col_name: Some("field1".to_string()),
+      value: Some("value1".to_string()),
+      col_version: 1,
+      db_version: 1,
+      node_id: 1,
+      local_db_version: 1,
+      flags: 0,
+    }];
 
-        // Write to first segment
-        let mut writer: WalWriter<String, String, String> = WalWriter::new(temp_dir.clone()).unwrap();
-        writer.append(&changes).unwrap();
+    // Write to first segment
+    let mut writer: WalWriter<String, String, String> = WalWriter::new(temp_dir.clone()).unwrap();
+    writer.append(&changes).unwrap();
 
-        // Verify segment 1 exists
-        assert!(temp_dir.join("wal_000001.bin").exists());
+    // Verify segment 1 exists
+    assert!(temp_dir.join("wal_000001.bin").exists());
 
-        // Rotate (with empty hooks)
-        let hooks: Vec<Box<dyn WalSegmentHook>> = Vec::new();
-        writer.rotate(&temp_dir, &hooks).unwrap();
+    // Rotate (with empty hooks)
+    let hooks: Vec<Box<dyn WalSegmentHook>> = Vec::new();
+    writer.rotate(&temp_dir, &hooks).unwrap();
 
-        // Old segment should still exist (not auto-deleted), new segment 2 should exist
-        assert!(temp_dir.join("wal_000001.bin").exists(), "Old segment should still exist");
-        assert!(temp_dir.join("wal_000002.bin").exists(), "New segment should exist");
+    // Old segment should still exist (not auto-deleted), new segment 2 should exist
+    assert!(
+      temp_dir.join("wal_000001.bin").exists(),
+      "Old segment should still exist"
+    );
+    assert!(
+      temp_dir.join("wal_000002.bin").exists(),
+      "New segment should exist"
+    );
 
-        // Write to new segment
-        writer.append(&changes).unwrap();
+    // Write to new segment
+    writer.append(&changes).unwrap();
 
-        // Cleanup
-        let _ = std::fs::remove_dir_all(&temp_dir);
-    }
+    // Cleanup
+    let _ = std::fs::remove_dir_all(&temp_dir);
+  }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -557,7 +557,10 @@ fn test_large_version_numbers() {
   let mut crdt: CRDT<String, String, String> = CRDT::from_changes(1, changes);
 
   // This should not panic even with very large version numbers
-  let new_changes = crdt.insert_or_update(&record_id, vec![("field2".to_string(), "value".to_string())]);
+  let new_changes = crdt.insert_or_update(
+    &record_id,
+    vec![("field2".to_string(), "value".to_string())],
+  );
 
   assert_eq!(new_changes.len(), 1);
   assert!(new_changes[0].db_version > u64::MAX - 100);
@@ -637,7 +640,10 @@ fn test_partial_field_updates() {
   // Verify that ONLY the role field changed, other fields remain unchanged
   let record_after = crdt.get_record(&record_id).unwrap();
   assert_eq!(record_after.fields.get("name").unwrap(), "Alice"); // Unchanged
-  assert_eq!(record_after.fields.get("email").unwrap(), "alice@example.com"); // Unchanged
+  assert_eq!(
+    record_after.fields.get("email").unwrap(),
+    "alice@example.com"
+  ); // Unchanged
   assert_eq!(record_after.fields.get("role").unwrap(), "admin"); // Changed
   assert_eq!(record_after.fields.get("status").unwrap(), "active"); // Unchanged
 

--- a/tests/persist_tests.rs
+++ b/tests/persist_tests.rs
@@ -1,612 +1,614 @@
-#![cfg(any(feature = "persist", feature = "persist-msgpack", feature = "persist-compressed"))]
+#![cfg(any(
+  feature = "persist",
+  feature = "persist-msgpack",
+  feature = "persist-compressed"
+))]
 
-use crdt_lite::persist::{PersistedCRDT, PersistConfig};
+use crdt_lite::persist::{PersistConfig, PersistedCRDT};
 use crdt_lite::{Change, CRDT};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 fn temp_dir(name: &str) -> PathBuf {
-    let dir = std::env::temp_dir().join(format!("crdt_persist_test_{}", name));
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
-    dir
+  let dir = std::env::temp_dir().join(format!("crdt_persist_test_{}", name));
+  let _ = std::fs::remove_dir_all(&dir);
+  std::fs::create_dir_all(&dir).unwrap();
+  dir
 }
 
 #[test]
 fn test_basic_persistence() {
-    let dir = temp_dir("basic");
+  let dir = temp_dir("basic");
 
-    // Create and write some data
-    {
-        let mut pcrdt =
-            PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
-                .unwrap();
+  // Create and write some data
+  {
+    let mut pcrdt =
+      PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
+        .unwrap();
 
-        let changes = pcrdt
-            .insert_or_update(
-                &"user1".to_string(),
-                [
-                    ("name".to_string(), "Alice".to_string()),
-                    ("age".to_string(), "30".to_string()),
-                ]
-                .into_iter(),
-            )
-            .unwrap();
+    let changes = pcrdt
+      .insert_or_update(
+        &"user1".to_string(),
+        [
+          ("name".to_string(), "Alice".to_string()),
+          ("age".to_string(), "30".to_string()),
+        ]
+        .into_iter(),
+      )
+      .unwrap();
 
-        assert_eq!(changes.len(), 2);
-    }
+    assert_eq!(changes.len(), 2);
+  }
 
-    // Reopen and verify data persisted
-    {
-        let pcrdt =
-            PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
-                .unwrap();
+  // Reopen and verify data persisted
+  {
+    let pcrdt =
+      PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
+        .unwrap();
 
-        let record = pcrdt.crdt().get_record(&"user1".to_string()).unwrap();
-        assert_eq!(record.fields.get("name").unwrap(), "Alice");
-        assert_eq!(record.fields.get("age").unwrap(), "30");
-    }
+    let record = pcrdt.crdt().get_record(&"user1".to_string()).unwrap();
+    assert_eq!(record.fields.get("name").unwrap(), "Alice");
+    assert_eq!(record.fields.get("age").unwrap(), "30");
+  }
 
-    let _ = std::fs::remove_dir_all(&dir);
+  let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn test_wal_replay() {
-    let dir = temp_dir("wal_replay");
+  let dir = temp_dir("wal_replay");
 
-    // Create and write multiple operations
-    {
-        let mut pcrdt =
-            PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
-                .unwrap();
+  // Create and write multiple operations
+  {
+    let mut pcrdt =
+      PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
+        .unwrap();
 
-        // Insert 3 records
-        pcrdt
-            .insert_or_update(
-                &"rec1".to_string(),
-                [("field".to_string(), "value1".to_string())].into_iter(),
-            )
-            .unwrap();
+    // Insert 3 records
+    pcrdt
+      .insert_or_update(
+        &"rec1".to_string(),
+        [("field".to_string(), "value1".to_string())].into_iter(),
+      )
+      .unwrap();
 
-        pcrdt
-            .insert_or_update(
-                &"rec2".to_string(),
-                [("field".to_string(), "value2".to_string())].into_iter(),
-            )
-            .unwrap();
+    pcrdt
+      .insert_or_update(
+        &"rec2".to_string(),
+        [("field".to_string(), "value2".to_string())].into_iter(),
+      )
+      .unwrap();
 
-        pcrdt
-            .insert_or_update(
-                &"rec3".to_string(),
-                [("field".to_string(), "value3".to_string())].into_iter(),
-            )
-            .unwrap();
+    pcrdt
+      .insert_or_update(
+        &"rec3".to_string(),
+        [("field".to_string(), "value3".to_string())].into_iter(),
+      )
+      .unwrap();
 
-        // Update one record
-        pcrdt
-            .insert_or_update(
-                &"rec1".to_string(),
-                [("field".to_string(), "updated".to_string())].into_iter(),
-            )
-            .unwrap();
+    // Update one record
+    pcrdt
+      .insert_or_update(
+        &"rec1".to_string(),
+        [("field".to_string(), "updated".to_string())].into_iter(),
+      )
+      .unwrap();
 
-        // Delete one record
-        pcrdt.delete_record(&"rec2".to_string()).unwrap();
-    }
+    // Delete one record
+    pcrdt.delete_record(&"rec2".to_string()).unwrap();
+  }
 
-    // Reopen and verify all operations replayed correctly
-    {
-        let pcrdt =
-            PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
-                .unwrap();
+  // Reopen and verify all operations replayed correctly
+  {
+    let pcrdt =
+      PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
+        .unwrap();
 
-        // rec1 should have updated value
-        let rec1 = pcrdt.crdt().get_record(&"rec1".to_string()).unwrap();
-        assert_eq!(rec1.fields.get("field").unwrap(), "updated");
+    // rec1 should have updated value
+    let rec1 = pcrdt.crdt().get_record(&"rec1".to_string()).unwrap();
+    assert_eq!(rec1.fields.get("field").unwrap(), "updated");
 
-        // rec2 should be tombstoned
-        assert!(pcrdt.crdt().is_tombstoned(&"rec2".to_string()));
+    // rec2 should be tombstoned
+    assert!(pcrdt.crdt().is_tombstoned(&"rec2".to_string()));
 
-        // rec3 should exist
-        let rec3 = pcrdt.crdt().get_record(&"rec3".to_string()).unwrap();
-        assert_eq!(rec3.fields.get("field").unwrap(), "value3");
-    }
+    // rec3 should exist
+    let rec3 = pcrdt.crdt().get_record(&"rec3".to_string()).unwrap();
+    assert_eq!(rec3.fields.get("field").unwrap(), "value3");
+  }
 
-    let _ = std::fs::remove_dir_all(&dir);
+  let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn test_snapshot_rotation() {
-    let dir = temp_dir("snapshot_rotation");
+  let dir = temp_dir("snapshot_rotation");
 
-    let config = PersistConfig {
-        snapshot_threshold: 5,
-        auto_cleanup_snapshots: None, // Manual cleanup for testing
-        max_batch_size: Some(10000), // Default value
-        ..Default::default() // Use defaults for new fields
-    };
+  let config = PersistConfig {
+    snapshot_threshold: 5,
+    auto_cleanup_snapshots: None, // Manual cleanup for testing
+    max_batch_size: Some(10000),  // Default value
+    ..Default::default()          // Use defaults for new fields
+  };
 
-    let mut pcrdt =
-        PersistedCRDT::<String, String, String>::open(dir.clone(), 1, config).unwrap();
+  let mut pcrdt = PersistedCRDT::<String, String, String>::open(dir.clone(), 1, config).unwrap();
 
-    // Insert 10 records (should trigger 2 snapshots)
-    for i in 0..10 {
-        pcrdt
-            .insert_or_update(
-                &format!("rec{}", i),
-                [("field".to_string(), format!("value{}", i))].into_iter(),
-            )
-            .unwrap();
-    }
+  // Insert 10 records (should trigger 2 snapshots)
+  for i in 0..10 {
+    pcrdt
+      .insert_or_update(
+        &format!("rec{}", i),
+        [("field".to_string(), format!("value{}", i))].into_iter(),
+      )
+      .unwrap();
+  }
 
-    // Should have versioned snapshot files
-    let snapshot_files: Vec<_> = std::fs::read_dir(&dir)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.file_name()
-                .to_string_lossy()
-                .starts_with("snapshot_")
-        })
-        .collect();
-    assert!(snapshot_files.len() > 0, "Should have at least one snapshot");
+  // Should have versioned snapshot files
+  let snapshot_files: Vec<_> = std::fs::read_dir(&dir)
+    .unwrap()
+    .filter_map(|e| e.ok())
+    .filter(|e| e.file_name().to_string_lossy().starts_with("snapshot_"))
+    .collect();
+  assert!(
+    snapshot_files.len() > 0,
+    "Should have at least one snapshot"
+  );
 
-    // Should have a current WAL segment but old ones deleted after snapshot
-    let wal_files: Vec<_> = std::fs::read_dir(&dir)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.file_name()
-                .to_string_lossy()
-                .starts_with("wal_")
-        })
-        .collect();
+  // Should have a current WAL segment but old ones deleted after snapshot
+  let wal_files: Vec<_> = std::fs::read_dir(&dir)
+    .unwrap()
+    .filter_map(|e| e.ok())
+    .filter(|e| e.file_name().to_string_lossy().starts_with("wal_"))
+    .collect();
 
-    // Should have at least the current WAL segment
-    assert!(wal_files.len() > 0, "Should have current WAL segment");
+  // Should have at least the current WAL segment
+  assert!(wal_files.len() > 0, "Should have current WAL segment");
 
-    // Reopen and verify all data present
-    let pcrdt =
-        PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
-            .unwrap();
+  // Reopen and verify all data present
+  let pcrdt =
+    PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
+      .unwrap();
 
-    for i in 0..10 {
-        let rec = pcrdt.crdt().get_record(&format!("rec{}", i)).unwrap();
-        assert_eq!(rec.fields.get("field").unwrap(), &format!("value{}", i));
-    }
+  for i in 0..10 {
+    let rec = pcrdt.crdt().get_record(&format!("rec{}", i)).unwrap();
+    assert_eq!(rec.fields.get("field").unwrap(), &format!("value{}", i));
+  }
 
-    let _ = std::fs::remove_dir_all(&dir);
+  let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn test_merge_remote_changes() {
-    let dir = temp_dir("merge_remote");
+  let dir = temp_dir("merge_remote");
 
-    let mut pcrdt1 =
-        PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
-            .unwrap();
+  let mut pcrdt1 =
+    PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
+      .unwrap();
 
-    // Create a second CRDT (simulating remote node)
-    let mut crdt2: CRDT<String, String, String> = CRDT::new(2, None);
+  // Create a second CRDT (simulating remote node)
+  let mut crdt2: CRDT<String, String, String> = CRDT::new(2, None);
 
-    // Both insert to same record with different fields
-    pcrdt1
-        .insert_or_update(
-            &"user".to_string(),
-            [("name".to_string(), "Alice".to_string())].into_iter(),
-        )
-        .unwrap();
+  // Both insert to same record with different fields
+  pcrdt1
+    .insert_or_update(
+      &"user".to_string(),
+      [("name".to_string(), "Alice".to_string())].into_iter(),
+    )
+    .unwrap();
 
-    let changes2 = crdt2.insert_or_update(
-        &"user".to_string(),
-        [("age".to_string(), "30".to_string())].into_iter(),
-    );
+  let changes2 = crdt2.insert_or_update(
+    &"user".to_string(),
+    [("age".to_string(), "30".to_string())].into_iter(),
+  );
 
-    // Merge remote changes into persisted CRDT
-    let accepted = pcrdt1.merge_changes(changes2).unwrap();
-    assert_eq!(accepted.len(), 1);
+  // Merge remote changes into persisted CRDT
+  let accepted = pcrdt1.merge_changes(changes2).unwrap();
+  assert_eq!(accepted.len(), 1);
 
-    // Verify both fields present
-    let record = pcrdt1.crdt().get_record(&"user".to_string()).unwrap();
-    assert_eq!(record.fields.get("name").unwrap(), "Alice");
-    assert_eq!(record.fields.get("age").unwrap(), "30");
+  // Verify both fields present
+  let record = pcrdt1.crdt().get_record(&"user".to_string()).unwrap();
+  assert_eq!(record.fields.get("name").unwrap(), "Alice");
+  assert_eq!(record.fields.get("age").unwrap(), "30");
 
-    // Reopen and verify merged state persisted
-    let pcrdt =
-        PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
-            .unwrap();
+  // Reopen and verify merged state persisted
+  let pcrdt =
+    PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
+      .unwrap();
 
-    let record = pcrdt.crdt().get_record(&"user".to_string()).unwrap();
-    assert_eq!(record.fields.get("name").unwrap(), "Alice");
-    assert_eq!(record.fields.get("age").unwrap(), "30");
+  let record = pcrdt.crdt().get_record(&"user".to_string()).unwrap();
+  assert_eq!(record.fields.get("name").unwrap(), "Alice");
+  assert_eq!(record.fields.get("age").unwrap(), "30");
 
-    let _ = std::fs::remove_dir_all(&dir);
+  let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn test_post_operation_hook() {
-    let dir = temp_dir("post_hook");
+  let dir = temp_dir("post_hook");
 
-    let mut pcrdt =
-        PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
-            .unwrap();
+  let mut pcrdt =
+    PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
+      .unwrap();
 
-    // Track changes via hook
-    let collected = Arc::new(Mutex::new(Vec::new()));
-    let collected_clone = collected.clone();
+  // Track changes via hook
+  let collected = Arc::new(Mutex::new(Vec::new()));
+  let collected_clone = collected.clone();
 
-    pcrdt.add_post_hook(Box::new(move |changes: &[Change<String, String, String>]| {
-        collected_clone.lock().unwrap().extend_from_slice(changes);
-    }));
+  pcrdt.add_post_hook(Box::new(
+    move |changes: &[Change<String, String, String>]| {
+      collected_clone.lock().unwrap().extend_from_slice(changes);
+    },
+  ));
 
-    // Perform operations
-    pcrdt
-        .insert_or_update(
-            &"rec1".to_string(),
-            [("field".to_string(), "value1".to_string())].into_iter(),
-        )
-        .unwrap();
+  // Perform operations
+  pcrdt
+    .insert_or_update(
+      &"rec1".to_string(),
+      [("field".to_string(), "value1".to_string())].into_iter(),
+    )
+    .unwrap();
 
-    pcrdt
-        .insert_or_update(
-            &"rec2".to_string(),
-            [("field".to_string(), "value2".to_string())].into_iter(),
-        )
-        .unwrap();
+  pcrdt
+    .insert_or_update(
+      &"rec2".to_string(),
+      [("field".to_string(), "value2".to_string())].into_iter(),
+    )
+    .unwrap();
 
-    // Verify hook was called
-    let changes = collected.lock().unwrap();
-    assert_eq!(changes.len(), 2);
-    assert_eq!(changes[0].record_id, "rec1");
-    assert_eq!(changes[1].record_id, "rec2");
+  // Verify hook was called
+  let changes = collected.lock().unwrap();
+  assert_eq!(changes.len(), 2);
+  assert_eq!(changes[0].record_id, "rec1");
+  assert_eq!(changes[1].record_id, "rec2");
 
-    let _ = std::fs::remove_dir_all(&dir);
+  let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn test_batch_collector() {
-    let dir = temp_dir("batch_collector");
+  let dir = temp_dir("batch_collector");
 
-    let mut pcrdt =
-        PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
-            .unwrap();
+  let mut pcrdt =
+    PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
+      .unwrap();
 
-    // Perform multiple operations
-    pcrdt
-        .insert_or_update(
-            &"rec1".to_string(),
-            [("field".to_string(), "value1".to_string())].into_iter(),
-        )
-        .unwrap();
+  // Perform multiple operations
+  pcrdt
+    .insert_or_update(
+      &"rec1".to_string(),
+      [("field".to_string(), "value1".to_string())].into_iter(),
+    )
+    .unwrap();
 
-    pcrdt
-        .insert_or_update(
-            &"rec2".to_string(),
-            [("field".to_string(), "value2".to_string())].into_iter(),
-        )
-        .unwrap();
+  pcrdt
+    .insert_or_update(
+      &"rec2".to_string(),
+      [("field".to_string(), "value2".to_string())].into_iter(),
+    )
+    .unwrap();
 
-    // Check batch has accumulated changes
-    assert_eq!(pcrdt.peek_batch().len(), 2);
+  // Check batch has accumulated changes
+  assert_eq!(pcrdt.peek_batch().len(), 2);
 
-    // Take batch (clears it)
-    let batch = pcrdt.take_batch();
-    assert_eq!(batch.len(), 2);
-    assert_eq!(pcrdt.peek_batch().len(), 0);
+  // Take batch (clears it)
+  let batch = pcrdt.take_batch();
+  assert_eq!(batch.len(), 2);
+  assert_eq!(pcrdt.peek_batch().len(), 0);
 
-    // Do more operations
-    pcrdt
-        .insert_or_update(
-            &"rec3".to_string(),
-            [("field".to_string(), "value3".to_string())].into_iter(),
-        )
-        .unwrap();
+  // Do more operations
+  pcrdt
+    .insert_or_update(
+      &"rec3".to_string(),
+      [("field".to_string(), "value3".to_string())].into_iter(),
+    )
+    .unwrap();
 
-    assert_eq!(pcrdt.peek_batch().len(), 1);
+  assert_eq!(pcrdt.peek_batch().len(), 1);
 
-    let _ = std::fs::remove_dir_all(&dir);
+  let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn test_manual_snapshot() {
-    let dir = temp_dir("manual_snapshot");
+  let dir = temp_dir("manual_snapshot");
 
-    let mut pcrdt =
-        PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
-            .unwrap();
+  let mut pcrdt =
+    PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
+      .unwrap();
 
-    // Insert some data
-    pcrdt
-        .insert_or_update(
-            &"rec1".to_string(),
-            [("field".to_string(), "value1".to_string())].into_iter(),
-        )
-        .unwrap();
+  // Insert some data
+  pcrdt
+    .insert_or_update(
+      &"rec1".to_string(),
+      [("field".to_string(), "value1".to_string())].into_iter(),
+    )
+    .unwrap();
 
-    assert_eq!(pcrdt.changes_since_snapshot(), 1);
+  assert_eq!(pcrdt.changes_since_snapshot(), 1);
 
-    // Manually trigger snapshot
-    pcrdt.snapshot().unwrap();
+  // Manually trigger snapshot
+  pcrdt.snapshot().unwrap();
 
-    // Counter should reset
-    assert_eq!(pcrdt.changes_since_snapshot(), 0);
+  // Counter should reset
+  assert_eq!(pcrdt.changes_since_snapshot(), 0);
 
-    // Snapshot file should exist (versioned)
-    let has_snapshot = std::fs::read_dir(&dir)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .any(|e| e.file_name().to_string_lossy().starts_with("snapshot_"));
-    assert!(has_snapshot, "Should have a versioned snapshot file");
+  // Snapshot file should exist (versioned)
+  let has_snapshot = std::fs::read_dir(&dir)
+    .unwrap()
+    .filter_map(|e| e.ok())
+    .any(|e| e.file_name().to_string_lossy().starts_with("snapshot_"));
+  assert!(has_snapshot, "Should have a versioned snapshot file");
 
-    let _ = std::fs::remove_dir_all(&dir);
+  let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn test_get_changes_since() {
-    let dir = temp_dir("get_changes_since");
+  let dir = temp_dir("get_changes_since");
 
-    let mut pcrdt =
-        PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
-            .unwrap();
+  let mut pcrdt =
+    PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
+      .unwrap();
 
-    // Get initial clock time
-    let initial_time = pcrdt.get_clock_time();
+  // Get initial clock time
+  let initial_time = pcrdt.get_clock_time();
 
-    // Insert some data
-    pcrdt
-        .insert_or_update(
-            &"rec1".to_string(),
-            [("field".to_string(), "value1".to_string())].into_iter(),
-        )
-        .unwrap();
+  // Insert some data
+  pcrdt
+    .insert_or_update(
+      &"rec1".to_string(),
+      [("field".to_string(), "value1".to_string())].into_iter(),
+    )
+    .unwrap();
 
-    pcrdt
-        .insert_or_update(
-            &"rec2".to_string(),
-            [("field".to_string(), "value2".to_string())].into_iter(),
-        )
-        .unwrap();
+  pcrdt
+    .insert_or_update(
+      &"rec2".to_string(),
+      [("field".to_string(), "value2".to_string())].into_iter(),
+    )
+    .unwrap();
 
-    // Get changes since initial time
-    let changes = pcrdt.get_changes_since(initial_time);
-    assert_eq!(changes.len(), 2);
+  // Get changes since initial time
+  let changes = pcrdt.get_changes_since(initial_time);
+  assert_eq!(changes.len(), 2);
 
-    // Get changes from current time (should be empty)
-    let current_time = pcrdt.get_clock_time();
-    let no_changes = pcrdt.get_changes_since(current_time);
-    assert_eq!(no_changes.len(), 0);
+  // Get changes from current time (should be empty)
+  let current_time = pcrdt.get_clock_time();
+  let no_changes = pcrdt.get_changes_since(current_time);
+  assert_eq!(no_changes.len(), 0);
 
-    let _ = std::fs::remove_dir_all(&dir);
+  let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn test_compact_tombstones_with_persistence() {
-    let dir = temp_dir("compact_tombstones");
+  let dir = temp_dir("compact_tombstones");
 
-    let mut pcrdt =
-        PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
-            .unwrap();
+  let mut pcrdt =
+    PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
+      .unwrap();
 
-    // Create and delete some records
-    pcrdt
-        .insert_or_update(
-            &"rec1".to_string(),
-            [("field".to_string(), "value1".to_string())].into_iter(),
-        )
-        .unwrap();
+  // Create and delete some records
+  pcrdt
+    .insert_or_update(
+      &"rec1".to_string(),
+      [("field".to_string(), "value1".to_string())].into_iter(),
+    )
+    .unwrap();
 
-    pcrdt.delete_record(&"rec1".to_string()).unwrap();
+  pcrdt.delete_record(&"rec1".to_string()).unwrap();
 
-    // Verify tombstone exists
-    assert!(pcrdt.crdt().is_tombstoned(&"rec1".to_string()));
-    assert_eq!(pcrdt.crdt().tombstone_count(), 1);
+  // Verify tombstone exists
+  assert!(pcrdt.crdt().is_tombstoned(&"rec1".to_string()));
+  assert_eq!(pcrdt.crdt().tombstone_count(), 1);
 
-    // Compact tombstones (automatically cleans up WAL)
-    // Use a version higher than current to ensure tombstone is compacted
-    let clock_time = pcrdt.get_clock_time() + 1;
-    pcrdt.compact_tombstones(clock_time).unwrap();
+  // Compact tombstones (automatically cleans up WAL)
+  // Use a version higher than current to ensure tombstone is compacted
+  let clock_time = pcrdt.get_clock_time() + 1;
+  pcrdt.compact_tombstones(clock_time).unwrap();
 
-    // Tombstone should be gone
-    assert_eq!(pcrdt.crdt().tombstone_count(), 0);
+  // Tombstone should be gone
+  assert_eq!(pcrdt.crdt().tombstone_count(), 0);
 
-    // Reopen and verify compaction persisted
-    let pcrdt =
-        PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
-            .unwrap();
+  // Reopen and verify compaction persisted
+  let pcrdt =
+    PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
+      .unwrap();
 
-    assert_eq!(pcrdt.crdt().tombstone_count(), 0);
+  assert_eq!(pcrdt.crdt().tombstone_count(), 0);
 
-    let _ = std::fs::remove_dir_all(&dir);
+  let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn test_tombstone_compaction_prevents_zombies() {
-    // This test verifies that compact_tombstones() prevents zombie records
-    // by automatically cleaning up WAL segments
-    let dir = temp_dir("zombie_prevention");
+  // This test verifies that compact_tombstones() prevents zombie records
+  // by automatically cleaning up WAL segments
+  let dir = temp_dir("zombie_prevention");
 
-    // Create a record, delete it, and compact
-    {
-        let mut pcrdt =
-            PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
-                .unwrap();
+  // Create a record, delete it, and compact
+  {
+    let mut pcrdt =
+      PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
+        .unwrap();
 
-        // Create and delete a record
-        pcrdt
-            .insert_or_update(
-                &"zombie".to_string(),
-                [("data".to_string(), "stays_deleted".to_string())].into_iter(),
-            )
-            .unwrap();
+    // Create and delete a record
+    pcrdt
+      .insert_or_update(
+        &"zombie".to_string(),
+        [("data".to_string(), "stays_deleted".to_string())].into_iter(),
+      )
+      .unwrap();
 
-        pcrdt.delete_record(&"zombie".to_string()).unwrap();
+    pcrdt.delete_record(&"zombie".to_string()).unwrap();
 
-        // Verify tombstone exists
-        assert!(pcrdt.crdt().is_tombstoned(&"zombie".to_string()));
-        assert_eq!(pcrdt.crdt().tombstone_count(), 1);
+    // Verify tombstone exists
+    assert!(pcrdt.crdt().is_tombstoned(&"zombie".to_string()));
+    assert_eq!(pcrdt.crdt().tombstone_count(), 1);
 
-        // Compact tombstones (atomically cleans up WAL)
-        let clock_time = pcrdt.get_clock_time() + 1;
-        pcrdt.compact_tombstones(clock_time).unwrap();
+    // Compact tombstones (atomically cleans up WAL)
+    let clock_time = pcrdt.get_clock_time() + 1;
+    pcrdt.compact_tombstones(clock_time).unwrap();
 
-        // Tombstone is gone from memory
-        assert_eq!(pcrdt.crdt().tombstone_count(), 0);
-    }
+    // Tombstone is gone from memory
+    assert_eq!(pcrdt.crdt().tombstone_count(), 0);
+  }
 
-    // Reopen and verify tombstone stays gone (no zombie records)
-    {
-        let pcrdt =
-            PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
-                .unwrap();
+  // Reopen and verify tombstone stays gone (no zombie records)
+  {
+    let pcrdt =
+      PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
+        .unwrap();
 
-        // Tombstone should stay gone - no zombie records!
-        assert_eq!(pcrdt.crdt().tombstone_count(), 0);
-        assert!(!pcrdt.crdt().is_tombstoned(&"zombie".to_string()));
-    }
+    // Tombstone should stay gone - no zombie records!
+    assert_eq!(pcrdt.crdt().tombstone_count(), 0);
+    assert!(!pcrdt.crdt().is_tombstoned(&"zombie".to_string()));
+  }
 
-    let _ = std::fs::remove_dir_all(&dir);
+  let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn test_crash_recovery() {
-    let dir = temp_dir("crash_recovery");
+  let dir = temp_dir("crash_recovery");
 
-    // Simulate crash by not properly closing
-    {
-        let mut pcrdt =
-            PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
-                .unwrap();
+  // Simulate crash by not properly closing
+  {
+    let mut pcrdt =
+      PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
+        .unwrap();
 
-        for i in 0..5 {
-            pcrdt
-                .insert_or_update(
-                    &format!("rec{}", i),
-                    [("field".to_string(), format!("value{}", i))].into_iter(),
-                )
-                .unwrap();
-        }
-        // Drop without explicit close - simulates crash
+    for i in 0..5 {
+      pcrdt
+        .insert_or_update(
+          &format!("rec{}", i),
+          [("field".to_string(), format!("value{}", i))].into_iter(),
+        )
+        .unwrap();
     }
+    // Drop without explicit close - simulates crash
+  }
 
-    // Reopen - should recover from WAL
-    {
-        let pcrdt =
-            PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
-                .unwrap();
+  // Reopen - should recover from WAL
+  {
+    let pcrdt =
+      PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
+        .unwrap();
 
-        // All records should be present
-        for i in 0..5 {
-            let rec = pcrdt.crdt().get_record(&format!("rec{}", i)).unwrap();
-            assert_eq!(rec.fields.get("field").unwrap(), &format!("value{}", i));
-        }
+    // All records should be present
+    for i in 0..5 {
+      let rec = pcrdt.crdt().get_record(&format!("rec{}", i)).unwrap();
+      assert_eq!(rec.fields.get("field").unwrap(), &format!("value{}", i));
     }
+  }
 
-    let _ = std::fs::remove_dir_all(&dir);
+  let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn test_multi_node_sync_with_persistence() {
-    let dir1 = temp_dir("sync_node1");
-    let dir2 = temp_dir("sync_node2");
+  let dir1 = temp_dir("sync_node1");
+  let dir2 = temp_dir("sync_node2");
 
-    let mut pcrdt1 =
-        PersistedCRDT::<String, String, String>::open(dir1.clone(), 1, PersistConfig::default())
-            .unwrap();
+  let mut pcrdt1 =
+    PersistedCRDT::<String, String, String>::open(dir1.clone(), 1, PersistConfig::default())
+      .unwrap();
 
-    let mut pcrdt2 =
-        PersistedCRDT::<String, String, String>::open(dir2.clone(), 2, PersistConfig::default())
-            .unwrap();
+  let mut pcrdt2 =
+    PersistedCRDT::<String, String, String>::open(dir2.clone(), 2, PersistConfig::default())
+      .unwrap();
 
-    // Node 1 creates records
-    pcrdt1
-        .insert_or_update(
-            &"shared".to_string(),
-            [("from_node1".to_string(), "data1".to_string())].into_iter(),
-        )
-        .unwrap();
+  // Node 1 creates records
+  pcrdt1
+    .insert_or_update(
+      &"shared".to_string(),
+      [("from_node1".to_string(), "data1".to_string())].into_iter(),
+    )
+    .unwrap();
 
-    // Node 2 creates records
-    pcrdt2
-        .insert_or_update(
-            &"shared".to_string(),
-            [("from_node2".to_string(), "data2".to_string())].into_iter(),
-        )
-        .unwrap();
+  // Node 2 creates records
+  pcrdt2
+    .insert_or_update(
+      &"shared".to_string(),
+      [("from_node2".to_string(), "data2".to_string())].into_iter(),
+    )
+    .unwrap();
 
-    // Sync node1 → node2
-    let changes_from_1 = pcrdt1.get_changes_since(0);
-    pcrdt2.merge_changes(changes_from_1).unwrap();
+  // Sync node1 → node2
+  let changes_from_1 = pcrdt1.get_changes_since(0);
+  pcrdt2.merge_changes(changes_from_1).unwrap();
 
-    // Sync node2 → node1
-    let changes_from_2 = pcrdt2.get_changes_since(0);
-    pcrdt1.merge_changes(changes_from_2).unwrap();
+  // Sync node2 → node1
+  let changes_from_2 = pcrdt2.get_changes_since(0);
+  pcrdt1.merge_changes(changes_from_2).unwrap();
 
-    // Both nodes should have both fields
-    let rec1 = pcrdt1.crdt().get_record(&"shared".to_string()).unwrap();
-    assert_eq!(rec1.fields.get("from_node1").unwrap(), "data1");
-    assert_eq!(rec1.fields.get("from_node2").unwrap(), "data2");
+  // Both nodes should have both fields
+  let rec1 = pcrdt1.crdt().get_record(&"shared".to_string()).unwrap();
+  assert_eq!(rec1.fields.get("from_node1").unwrap(), "data1");
+  assert_eq!(rec1.fields.get("from_node2").unwrap(), "data2");
 
-    let rec2 = pcrdt2.crdt().get_record(&"shared".to_string()).unwrap();
-    assert_eq!(rec2.fields.get("from_node1").unwrap(), "data1");
-    assert_eq!(rec2.fields.get("from_node2").unwrap(), "data2");
+  let rec2 = pcrdt2.crdt().get_record(&"shared".to_string()).unwrap();
+  assert_eq!(rec2.fields.get("from_node1").unwrap(), "data1");
+  assert_eq!(rec2.fields.get("from_node2").unwrap(), "data2");
 
-    // Reopen both and verify persistence
-    let pcrdt1 =
-        PersistedCRDT::<String, String, String>::open(dir1.clone(), 1, PersistConfig::default())
-            .unwrap();
+  // Reopen both and verify persistence
+  let pcrdt1 =
+    PersistedCRDT::<String, String, String>::open(dir1.clone(), 1, PersistConfig::default())
+      .unwrap();
 
-    let pcrdt2 =
-        PersistedCRDT::<String, String, String>::open(dir2.clone(), 2, PersistConfig::default())
-            .unwrap();
+  let pcrdt2 =
+    PersistedCRDT::<String, String, String>::open(dir2.clone(), 2, PersistConfig::default())
+      .unwrap();
 
-    let rec1 = pcrdt1.crdt().get_record(&"shared".to_string()).unwrap();
-    assert_eq!(rec1.fields.get("from_node1").unwrap(), "data1");
-    assert_eq!(rec1.fields.get("from_node2").unwrap(), "data2");
+  let rec1 = pcrdt1.crdt().get_record(&"shared".to_string()).unwrap();
+  assert_eq!(rec1.fields.get("from_node1").unwrap(), "data1");
+  assert_eq!(rec1.fields.get("from_node2").unwrap(), "data2");
 
-    let rec2 = pcrdt2.crdt().get_record(&"shared".to_string()).unwrap();
-    assert_eq!(rec2.fields.get("from_node1").unwrap(), "data1");
-    assert_eq!(rec2.fields.get("from_node2").unwrap(), "data2");
+  let rec2 = pcrdt2.crdt().get_record(&"shared".to_string()).unwrap();
+  assert_eq!(rec2.fields.get("from_node1").unwrap(), "data1");
+  assert_eq!(rec2.fields.get("from_node2").unwrap(), "data2");
 
-    let _ = std::fs::remove_dir_all(&dir1);
-    let _ = std::fs::remove_dir_all(&dir2);
+  let _ = std::fs::remove_dir_all(&dir1);
+  let _ = std::fs::remove_dir_all(&dir2);
 }
 
 #[test]
 fn test_delete_field_persistence() {
-    let dir = temp_dir("delete_field");
+  let dir = temp_dir("delete_field");
 
-    let mut pcrdt =
-        PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
-            .unwrap();
+  let mut pcrdt =
+    PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
+      .unwrap();
 
-    // Insert record with multiple fields
-    pcrdt
-        .insert_or_update(
-            &"rec".to_string(),
-            [
-                ("field1".to_string(), "value1".to_string()),
-                ("field2".to_string(), "value2".to_string()),
-            ]
-            .into_iter(),
-        )
-        .unwrap();
+  // Insert record with multiple fields
+  pcrdt
+    .insert_or_update(
+      &"rec".to_string(),
+      [
+        ("field1".to_string(), "value1".to_string()),
+        ("field2".to_string(), "value2".to_string()),
+      ]
+      .into_iter(),
+    )
+    .unwrap();
 
-    // Delete one field
-    pcrdt.delete_field(&"rec".to_string(), &"field1".to_string()).unwrap();
+  // Delete one field
+  pcrdt
+    .delete_field(&"rec".to_string(), &"field1".to_string())
+    .unwrap();
 
-    // Verify field deleted
-    let rec = pcrdt.crdt().get_record(&"rec".to_string()).unwrap();
-    assert!(rec.fields.get("field1").is_none());
-    assert_eq!(rec.fields.get("field2").unwrap(), "value2");
+  // Verify field deleted
+  let rec = pcrdt.crdt().get_record(&"rec".to_string()).unwrap();
+  assert!(rec.fields.get("field1").is_none());
+  assert_eq!(rec.fields.get("field2").unwrap(), "value2");
 
-    // Reopen and verify
-    let pcrdt =
-        PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
-            .unwrap();
+  // Reopen and verify
+  let pcrdt =
+    PersistedCRDT::<String, String, String>::open(dir.clone(), 1, PersistConfig::default())
+      .unwrap();
 
-    let rec = pcrdt.crdt().get_record(&"rec".to_string()).unwrap();
-    assert!(rec.fields.get("field1").is_none());
-    assert_eq!(rec.fields.get("field2").unwrap(), "value2");
+  let rec = pcrdt.crdt().get_record(&"rec".to_string()).unwrap();
+  assert!(rec.fields.get("field1").is_none());
+  assert_eq!(rec.fields.get("field2").unwrap(), "value2");
 
-    let _ = std::fs::remove_dir_all(&dir);
+  let _ = std::fs::remove_dir_all(&dir);
 }

--- a/tests/test_msgpack_incremental.rs
+++ b/tests/test_msgpack_incremental.rs
@@ -1,461 +1,436 @@
-#![cfg(all(any(feature = "persist", feature = "persist-msgpack", feature = "persist-compressed"), feature = "msgpack"))]
+#![cfg(all(
+  any(
+    feature = "persist",
+    feature = "persist-msgpack",
+    feature = "persist-compressed"
+  ),
+  feature = "msgpack"
+))]
 
 //! Comprehensive tests for MessagePack + Incremental Snapshots functionality
 
-use crdt_lite::persist::{PersistedCRDT, PersistConfig, SnapshotFormat};
+use crdt_lite::persist::{PersistConfig, PersistedCRDT, SnapshotFormat};
 use tempfile::TempDir;
 
 #[test]
 fn test_msgpack_full_snapshot_basic() {
-    let temp_dir = TempDir::new().unwrap();
-    let base_path = temp_dir.path().to_path_buf();
+  let temp_dir = TempDir::new().unwrap();
+  let base_path = temp_dir.path().to_path_buf();
 
-    // Create CRDT with MessagePack format
-    let mut config = PersistConfig::default();
-    config.snapshot_format = SnapshotFormat::MessagePack;
-    config.enable_incremental_snapshots = false; // Force full snapshots only
-    config.snapshot_threshold = 5;
+  // Create CRDT with MessagePack format
+  let mut config = PersistConfig::default();
+  config.snapshot_format = SnapshotFormat::MessagePack;
+  config.enable_incremental_snapshots = false; // Force full snapshots only
+  config.snapshot_threshold = 5;
 
-    let mut pcrdt =
-        PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config).unwrap();
+  let mut pcrdt =
+    PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config).unwrap();
 
-    // Insert some data
-    for i in 0..5 {
-        pcrdt
-            .insert_or_update(
-                &format!("rec{}", i),
-                [("field".to_string(), format!("value{}", i))].into_iter(),
-            )
-            .unwrap();
-    }
+  // Insert some data
+  for i in 0..5 {
+    pcrdt
+      .insert_or_update(
+        &format!("rec{}", i),
+        [("field".to_string(), format!("value{}", i))].into_iter(),
+      )
+      .unwrap();
+  }
 
-    // Snapshot should have been created automatically
-    let snapshot_files: Vec<_> = std::fs::read_dir(&base_path)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.file_name()
-                .to_string_lossy()
-                .starts_with("snapshot_full_")
-        })
-        .collect();
+  // Snapshot should have been created automatically
+  let snapshot_files: Vec<_> = std::fs::read_dir(&base_path)
+    .unwrap()
+    .filter_map(|e| e.ok())
+    .filter(|e| {
+      e.file_name()
+        .to_string_lossy()
+        .starts_with("snapshot_full_")
+    })
+    .collect();
 
-    assert_eq!(snapshot_files.len(), 1);
+  assert_eq!(snapshot_files.len(), 1);
 
-    // Verify recovery
-    drop(pcrdt);
-    let recovered =
-        PersistedCRDT::<String, String, String>::open(base_path, 1, PersistConfig::default())
-            .unwrap();
+  // Verify recovery
+  drop(pcrdt);
+  let recovered =
+    PersistedCRDT::<String, String, String>::open(base_path, 1, PersistConfig::default()).unwrap();
 
-    for i in 0..5 {
-        let record = recovered
-            .crdt()
-            .get_record(&format!("rec{}", i))
-            .unwrap();
-        assert_eq!(
-            record.fields.get(&"field".to_string()).unwrap(),
-            &format!("value{}", i)
-        );
-    }
+  for i in 0..5 {
+    let record = recovered.crdt().get_record(&format!("rec{}", i)).unwrap();
+    assert_eq!(
+      record.fields.get(&"field".to_string()).unwrap(),
+      &format!("value{}", i)
+    );
+  }
 }
 
 #[test]
 fn test_incremental_snapshots_basic() {
-    let temp_dir = TempDir::new().unwrap();
-    let base_path = temp_dir.path().to_path_buf();
+  let temp_dir = TempDir::new().unwrap();
+  let base_path = temp_dir.path().to_path_buf();
 
-    // Create CRDT with incremental snapshots enabled
-    let mut config = PersistConfig::default();
-    config.snapshot_format = SnapshotFormat::MessagePack;
-    config.enable_incremental_snapshots = true;
-    config.full_snapshot_interval = 3; // Full every 3 incrementals
-    config.snapshot_threshold = 2;
+  // Create CRDT with incremental snapshots enabled
+  let mut config = PersistConfig::default();
+  config.snapshot_format = SnapshotFormat::MessagePack;
+  config.enable_incremental_snapshots = true;
+  config.full_snapshot_interval = 3; // Full every 3 incrementals
+  config.snapshot_threshold = 2;
 
-    let mut pcrdt =
-        PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config).unwrap();
+  let mut pcrdt =
+    PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config).unwrap();
 
-    // First batch - should create full snapshot
-    pcrdt
-        .insert_or_update(
-            &"rec1".to_string(),
-            [("field".to_string(), "value1".to_string())].into_iter(),
-        )
-        .unwrap();
-    pcrdt
-        .insert_or_update(
-            &"rec2".to_string(),
-            [("field".to_string(), "value2".to_string())].into_iter(),
-        )
-        .unwrap();
-
-    // Second batch - should create incremental
-    pcrdt
-        .insert_or_update(
-            &"rec3".to_string(),
-            [("field".to_string(), "value3".to_string())].into_iter(),
-        )
-        .unwrap();
-    pcrdt
-        .insert_or_update(
-            &"rec4".to_string(),
-            [("field".to_string(), "value4".to_string())].into_iter(),
-        )
-        .unwrap();
-
-    // Third batch - should create another incremental
-    pcrdt
-        .insert_or_update(
-            &"rec5".to_string(),
-            [("field".to_string(), "value5".to_string())].into_iter(),
-        )
-        .unwrap();
-    pcrdt
-        .insert_or_update(
-            &"rec6".to_string(),
-            [("field".to_string(), "value6".to_string())].into_iter(),
-        )
-        .unwrap();
-
-    // Verify we have 1 full and 2 incrementals
-    let files: Vec<_> = std::fs::read_dir(&base_path)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            let name = e.file_name().to_string_lossy().to_string();
-            name.starts_with("snapshot_")
-        })
-        .collect();
-
-    let full_count = files
-        .iter()
-        .filter(|e| {
-            e.file_name()
-                .to_string_lossy()
-                .starts_with("snapshot_full_")
-        })
-        .count();
-    let incr_count = files
-        .iter()
-        .filter(|e| {
-            e.file_name()
-                .to_string_lossy()
-                .starts_with("snapshot_incr_")
-        })
-        .count();
-
-    assert_eq!(full_count, 1, "Should have 1 full snapshot");
-    assert_eq!(incr_count, 2, "Should have 2 incremental snapshots");
-
-    // Verify recovery loads all data correctly
-    drop(pcrdt);
-    let recovered = PersistedCRDT::<String, String, String>::open(
-        base_path,
-        1,
-        PersistConfig::default(),
+  // First batch - should create full snapshot
+  pcrdt
+    .insert_or_update(
+      &"rec1".to_string(),
+      [("field".to_string(), "value1".to_string())].into_iter(),
+    )
+    .unwrap();
+  pcrdt
+    .insert_or_update(
+      &"rec2".to_string(),
+      [("field".to_string(), "value2".to_string())].into_iter(),
     )
     .unwrap();
 
-    for i in 1..=6 {
-        let record = recovered
-            .crdt()
-            .get_record(&format!("rec{}", i))
-            .unwrap();
-        assert_eq!(
-            record.fields.get(&"field".to_string()).unwrap(),
-            &format!("value{}", i)
-        );
-    }
+  // Second batch - should create incremental
+  pcrdt
+    .insert_or_update(
+      &"rec3".to_string(),
+      [("field".to_string(), "value3".to_string())].into_iter(),
+    )
+    .unwrap();
+  pcrdt
+    .insert_or_update(
+      &"rec4".to_string(),
+      [("field".to_string(), "value4".to_string())].into_iter(),
+    )
+    .unwrap();
+
+  // Third batch - should create another incremental
+  pcrdt
+    .insert_or_update(
+      &"rec5".to_string(),
+      [("field".to_string(), "value5".to_string())].into_iter(),
+    )
+    .unwrap();
+  pcrdt
+    .insert_or_update(
+      &"rec6".to_string(),
+      [("field".to_string(), "value6".to_string())].into_iter(),
+    )
+    .unwrap();
+
+  // Verify we have 1 full and 2 incrementals
+  let files: Vec<_> = std::fs::read_dir(&base_path)
+    .unwrap()
+    .filter_map(|e| e.ok())
+    .filter(|e| {
+      let name = e.file_name().to_string_lossy().to_string();
+      name.starts_with("snapshot_")
+    })
+    .collect();
+
+  let full_count = files
+    .iter()
+    .filter(|e| {
+      e.file_name()
+        .to_string_lossy()
+        .starts_with("snapshot_full_")
+    })
+    .count();
+  let incr_count = files
+    .iter()
+    .filter(|e| {
+      e.file_name()
+        .to_string_lossy()
+        .starts_with("snapshot_incr_")
+    })
+    .count();
+
+  assert_eq!(full_count, 1, "Should have 1 full snapshot");
+  assert_eq!(incr_count, 2, "Should have 2 incremental snapshots");
+
+  // Verify recovery loads all data correctly
+  drop(pcrdt);
+  let recovered =
+    PersistedCRDT::<String, String, String>::open(base_path, 1, PersistConfig::default()).unwrap();
+
+  for i in 1..=6 {
+    let record = recovered.crdt().get_record(&format!("rec{}", i)).unwrap();
+    assert_eq!(
+      record.fields.get(&"field".to_string()).unwrap(),
+      &format!("value{}", i)
+    );
+  }
 }
 
 #[test]
 fn test_incremental_with_deletes() {
-    let temp_dir = TempDir::new().unwrap();
-    let base_path = temp_dir.path().to_path_buf();
+  let temp_dir = TempDir::new().unwrap();
+  let base_path = temp_dir.path().to_path_buf();
 
-    let mut config = PersistConfig::default();
-    config.snapshot_format = SnapshotFormat::MessagePack;
-    config.enable_incremental_snapshots = true;
-    config.snapshot_threshold = 2;
+  let mut config = PersistConfig::default();
+  config.snapshot_format = SnapshotFormat::MessagePack;
+  config.enable_incremental_snapshots = true;
+  config.snapshot_threshold = 2;
 
-    let mut pcrdt =
-        PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config).unwrap();
+  let mut pcrdt =
+    PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config).unwrap();
 
-    // First snapshot - create records
-    pcrdt
-        .insert_or_update(
-            &"rec1".to_string(),
-            [("field".to_string(), "value1".to_string())].into_iter(),
-        )
-        .unwrap();
-    pcrdt
-        .insert_or_update(
-            &"rec2".to_string(),
-            [("field".to_string(), "value2".to_string())].into_iter(),
-        )
-        .unwrap();
-
-    // Second snapshot - delete one record
-    pcrdt.delete_record(&"rec1".to_string()).unwrap();
-    pcrdt
-        .insert_or_update(
-            &"rec3".to_string(),
-            [("field".to_string(), "value3".to_string())].into_iter(),
-        )
-        .unwrap();
-
-    // Verify recovery
-    drop(pcrdt);
-    let recovered = PersistedCRDT::<String, String, String>::open(
-        base_path,
-        1,
-        PersistConfig::default(),
+  // First snapshot - create records
+  pcrdt
+    .insert_or_update(
+      &"rec1".to_string(),
+      [("field".to_string(), "value1".to_string())].into_iter(),
+    )
+    .unwrap();
+  pcrdt
+    .insert_or_update(
+      &"rec2".to_string(),
+      [("field".to_string(), "value2".to_string())].into_iter(),
     )
     .unwrap();
 
-    // rec1 should be tombstoned
-    assert!(recovered.crdt().is_tombstoned(&"rec1".to_string()));
+  // Second snapshot - delete one record
+  pcrdt.delete_record(&"rec1".to_string()).unwrap();
+  pcrdt
+    .insert_or_update(
+      &"rec3".to_string(),
+      [("field".to_string(), "value3".to_string())].into_iter(),
+    )
+    .unwrap();
 
-    // rec2 and rec3 should exist
-    assert!(recovered
-        .crdt()
-        .get_record(&"rec2".to_string())
-        .is_some());
-    assert!(recovered
-        .crdt()
-        .get_record(&"rec3".to_string())
-        .is_some());
+  // Verify recovery
+  drop(pcrdt);
+  let recovered =
+    PersistedCRDT::<String, String, String>::open(base_path, 1, PersistConfig::default()).unwrap();
+
+  // rec1 should be tombstoned
+  assert!(recovered.crdt().is_tombstoned(&"rec1".to_string()));
+
+  // rec2 and rec3 should exist
+  assert!(recovered.crdt().get_record(&"rec2".to_string()).is_some());
+  assert!(recovered.crdt().get_record(&"rec3".to_string()).is_some());
 }
 
 #[test]
 fn test_full_snapshot_after_interval() {
-    let temp_dir = TempDir::new().unwrap();
-    let base_path = temp_dir.path().to_path_buf();
+  let temp_dir = TempDir::new().unwrap();
+  let base_path = temp_dir.path().to_path_buf();
 
-    let mut config = PersistConfig::default();
-    config.snapshot_format = SnapshotFormat::MessagePack;
-    config.enable_incremental_snapshots = true;
-    config.full_snapshot_interval = 2; // Full after 2 incrementals
-    config.snapshot_threshold = 1;
+  let mut config = PersistConfig::default();
+  config.snapshot_format = SnapshotFormat::MessagePack;
+  config.enable_incremental_snapshots = true;
+  config.full_snapshot_interval = 2; // Full after 2 incrementals
+  config.snapshot_threshold = 1;
 
-    let mut pcrdt =
-        PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config).unwrap();
+  let mut pcrdt =
+    PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config).unwrap();
 
-    // Create 5 snapshots (should be: full, incr, incr, full, incr)
-    for i in 0..5 {
-        pcrdt
-            .insert_or_update(
-                &format!("rec{}", i),
-                [("field".to_string(), format!("value{}", i))].into_iter(),
-            )
-            .unwrap();
-    }
+  // Create 5 snapshots (should be: full, incr, incr, full, incr)
+  for i in 0..5 {
+    pcrdt
+      .insert_or_update(
+        &format!("rec{}", i),
+        [("field".to_string(), format!("value{}", i))].into_iter(),
+      )
+      .unwrap();
+  }
 
-    // Count snapshots
-    let files: Vec<_> = std::fs::read_dir(&base_path)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            let name = e.file_name().to_string_lossy().to_string();
-            name.starts_with("snapshot_")
-        })
-        .collect();
+  // Count snapshots
+  let files: Vec<_> = std::fs::read_dir(&base_path)
+    .unwrap()
+    .filter_map(|e| e.ok())
+    .filter(|e| {
+      let name = e.file_name().to_string_lossy().to_string();
+      name.starts_with("snapshot_")
+    })
+    .collect();
 
-    let full_count = files
-        .iter()
-        .filter(|e| {
-            e.file_name()
-                .to_string_lossy()
-                .starts_with("snapshot_full_")
-        })
-        .count();
+  let full_count = files
+    .iter()
+    .filter(|e| {
+      e.file_name()
+        .to_string_lossy()
+        .starts_with("snapshot_full_")
+    })
+    .count();
 
-    // Should have 2 full snapshots (after cleanup, might be less due to auto_cleanup_snapshots)
-    // At minimum we should have at least 1 full
-    assert!(full_count >= 1, "Should have at least 1 full snapshot");
+  // Should have 2 full snapshots (after cleanup, might be less due to auto_cleanup_snapshots)
+  // At minimum we should have at least 1 full
+  assert!(full_count >= 1, "Should have at least 1 full snapshot");
 }
 
 #[test]
 fn test_bincode_fallback() {
-    let temp_dir = TempDir::new().unwrap();
-    let base_path = temp_dir.path().to_path_buf();
+  let temp_dir = TempDir::new().unwrap();
+  let base_path = temp_dir.path().to_path_buf();
 
-    // Create with bincode format
-    let mut config = PersistConfig::default();
-    config.snapshot_format = SnapshotFormat::Bincode;
-    config.snapshot_threshold = 2;
+  // Create with bincode format
+  let mut config = PersistConfig::default();
+  config.snapshot_format = SnapshotFormat::Bincode;
+  config.snapshot_threshold = 2;
 
-    let mut pcrdt =
-        PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config).unwrap();
+  let mut pcrdt =
+    PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config).unwrap();
 
-    pcrdt
-        .insert_or_update(
-            &"rec1".to_string(),
-            [("field".to_string(), "value1".to_string())].into_iter(),
-        )
-        .unwrap();
-    pcrdt
-        .insert_or_update(
-            &"rec2".to_string(),
-            [("field".to_string(), "value2".to_string())].into_iter(),
-        )
-        .unwrap();
-
-    // Verify bincode snapshot exists
-    let bincode_files: Vec<_> = std::fs::read_dir(&base_path)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            let name = e.file_name().to_string_lossy().to_string();
-            name.starts_with("snapshot_") && name.ends_with(".bin")
-        })
-        .collect();
-
-    assert!(!bincode_files.is_empty(), "Should have bincode snapshot");
-
-    // Verify recovery
-    drop(pcrdt);
-    let recovered = PersistedCRDT::<String, String, String>::open(
-        base_path,
-        1,
-        PersistConfig::default(),
+  pcrdt
+    .insert_or_update(
+      &"rec1".to_string(),
+      [("field".to_string(), "value1".to_string())].into_iter(),
+    )
+    .unwrap();
+  pcrdt
+    .insert_or_update(
+      &"rec2".to_string(),
+      [("field".to_string(), "value2".to_string())].into_iter(),
     )
     .unwrap();
 
-    assert!(recovered
-        .crdt()
-        .get_record(&"rec1".to_string())
-        .is_some());
+  // Verify bincode snapshot exists
+  let bincode_files: Vec<_> = std::fs::read_dir(&base_path)
+    .unwrap()
+    .filter_map(|e| e.ok())
+    .filter(|e| {
+      let name = e.file_name().to_string_lossy().to_string();
+      name.starts_with("snapshot_") && name.ends_with(".bin")
+    })
+    .collect();
+
+  assert!(!bincode_files.is_empty(), "Should have bincode snapshot");
+
+  // Verify recovery
+  drop(pcrdt);
+  let recovered =
+    PersistedCRDT::<String, String, String>::open(base_path, 1, PersistConfig::default()).unwrap();
+
+  assert!(recovered.crdt().get_record(&"rec1".to_string()).is_some());
 }
 
 #[cfg(feature = "compression")]
 #[test]
 fn test_compression() {
-    let temp_dir = TempDir::new().unwrap();
-    let base_path = temp_dir.path().to_path_buf();
+  let temp_dir = TempDir::new().unwrap();
+  let base_path = temp_dir.path().to_path_buf();
 
-    let mut config = PersistConfig::default();
-    config.snapshot_format = SnapshotFormat::MessagePack;
-    config.enable_compression = true;
-    config.snapshot_threshold = 2;
+  let mut config = PersistConfig::default();
+  config.snapshot_format = SnapshotFormat::MessagePack;
+  config.enable_compression = true;
+  config.snapshot_threshold = 2;
 
-    let mut pcrdt =
-        PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config).unwrap();
+  let mut pcrdt =
+    PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config).unwrap();
 
-    // Insert compressible data
-    for i in 0..10 {
-        pcrdt
-            .insert_or_update(
-                &format!("rec{}", i),
-                [(
-                    "field".to_string(),
-                    "This is a long repeated string that should compress well".to_string(),
-                )]
-                .into_iter(),
-            )
-            .unwrap();
-    }
+  // Insert compressible data
+  for i in 0..10 {
+    pcrdt
+      .insert_or_update(
+        &format!("rec{}", i),
+        [(
+          "field".to_string(),
+          "This is a long repeated string that should compress well".to_string(),
+        )]
+        .into_iter(),
+      )
+      .unwrap();
+  }
 
-    // Force snapshot
-    pcrdt.snapshot().unwrap();
+  // Force snapshot
+  pcrdt.snapshot().unwrap();
 
-    // Verify recovery works with compression
-    drop(pcrdt);
-    let recovered = PersistedCRDT::<String, String, String>::open(
-        base_path,
-        1,
-        PersistConfig::default(),
-    )
-    .unwrap();
+  // Verify recovery works with compression
+  drop(pcrdt);
+  let recovered =
+    PersistedCRDT::<String, String, String>::open(base_path, 1, PersistConfig::default()).unwrap();
 
-    for i in 0..10 {
-        assert!(recovered
-            .crdt()
-            .get_record(&format!("rec{}", i))
-            .is_some());
-    }
+  for i in 0..10 {
+    assert!(recovered.crdt().get_record(&format!("rec{}", i)).is_some());
+  }
 }
 
 #[test]
 fn test_size_reduction() {
-    // This test demonstrates the size reduction from incremental snapshots
-    let temp_dir = TempDir::new().unwrap();
-    let base_path = temp_dir.path().to_path_buf();
+  // This test demonstrates the size reduction from incremental snapshots
+  let temp_dir = TempDir::new().unwrap();
+  let base_path = temp_dir.path().to_path_buf();
 
-    let mut config = PersistConfig::default();
-    config.snapshot_format = SnapshotFormat::MessagePack;
-    config.enable_incremental_snapshots = true;
-    config.snapshot_threshold = 100;
-    config.auto_cleanup_snapshots = None; // Don't clean up for size comparison
+  let mut config = PersistConfig::default();
+  config.snapshot_format = SnapshotFormat::MessagePack;
+  config.enable_incremental_snapshots = true;
+  config.snapshot_threshold = 100;
+  config.auto_cleanup_snapshots = None; // Don't clean up for size comparison
 
-    let mut pcrdt =
-        PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config).unwrap();
+  let mut pcrdt =
+    PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config).unwrap();
 
-    // Create many records
-    for i in 0..100 {
-        pcrdt
-            .insert_or_update(
-                &format!("rec{}", i),
-                [("field".to_string(), format!("value{}", i))].into_iter(),
-            )
-            .unwrap();
-    }
+  // Create many records
+  for i in 0..100 {
+    pcrdt
+      .insert_or_update(
+        &format!("rec{}", i),
+        [("field".to_string(), format!("value{}", i))].into_iter(),
+      )
+      .unwrap();
+  }
 
-    // Force full snapshot
-    pcrdt.snapshot().unwrap();
+  // Force full snapshot
+  pcrdt.snapshot().unwrap();
 
-    let full_size = std::fs::read_dir(&base_path)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.file_name()
-                .to_string_lossy()
-                .starts_with("snapshot_full_")
-        })
-        .next()
-        .and_then(|e| e.metadata().ok())
-        .map(|m| m.len())
-        .unwrap_or(0);
+  let full_size = std::fs::read_dir(&base_path)
+    .unwrap()
+    .filter_map(|e| e.ok())
+    .filter(|e| {
+      e.file_name()
+        .to_string_lossy()
+        .starts_with("snapshot_full_")
+    })
+    .next()
+    .and_then(|e| e.metadata().ok())
+    .map(|m| m.len())
+    .unwrap_or(0);
 
-    // Update only 5 records
-    for i in 0..5 {
-        pcrdt
-            .insert_or_update(
-                &format!("rec{}", i),
-                [("field".to_string(), format!("updated{}", i))].into_iter(),
-            )
-            .unwrap();
-    }
+  // Update only 5 records
+  for i in 0..5 {
+    pcrdt
+      .insert_or_update(
+        &format!("rec{}", i),
+        [("field".to_string(), format!("updated{}", i))].into_iter(),
+      )
+      .unwrap();
+  }
 
-    // Force incremental snapshot
-    pcrdt.snapshot().unwrap();
+  // Force incremental snapshot
+  pcrdt.snapshot().unwrap();
 
-    let incr_size = std::fs::read_dir(&base_path)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.file_name()
-                .to_string_lossy()
-                .starts_with("snapshot_incr_")
-        })
-        .next()
-        .and_then(|e| e.metadata().ok())
-        .map(|m| m.len())
-        .unwrap_or(0);
+  let incr_size = std::fs::read_dir(&base_path)
+    .unwrap()
+    .filter_map(|e| e.ok())
+    .filter(|e| {
+      e.file_name()
+        .to_string_lossy()
+        .starts_with("snapshot_incr_")
+    })
+    .next()
+    .and_then(|e| e.metadata().ok())
+    .map(|m| m.len())
+    .unwrap_or(0);
 
-    // Log sizes for debugging (only if RUST_LOG is set)
-    #[cfg(test)]
-    if std::env::var("RUST_LOG").is_ok() {
-        eprintln!("Full snapshot size: {} bytes", full_size);
-        eprintln!("Incremental snapshot size: {} bytes", incr_size);
-        eprintln!("Reduction: {:.1}%", (1.0 - (incr_size as f64 / full_size as f64)) * 100.0);
-    }
-
-    // Incremental should be much smaller (at least 80% smaller for 5% changes)
-    assert!(
-        incr_size < full_size / 5,
-        "Incremental snapshot should be significantly smaller"
+  // Log sizes for debugging (only if RUST_LOG is set)
+  #[cfg(test)]
+  if std::env::var("RUST_LOG").is_ok() {
+    eprintln!("Full snapshot size: {} bytes", full_size);
+    eprintln!("Incremental snapshot size: {} bytes", incr_size);
+    eprintln!(
+      "Reduction: {:.1}%",
+      (1.0 - (incr_size as f64 / full_size as f64)) * 100.0
     );
+  }
+
+  // Incremental should be much smaller (at least 80% smaller for 5% changes)
+  assert!(
+    incr_size < full_size / 5,
+    "Incremental snapshot should be significantly smaller"
+  );
 }
 
 /// CRITICAL TEST: Verifies that tombstone node_id is preserved during incremental snapshot recovery.
@@ -472,129 +447,129 @@ fn test_size_reduction() {
 /// 5. Node 3 creates "user1" → conflict resolution uses wrong node_id → incorrect winner
 #[test]
 fn test_incremental_tombstone_preserves_node_id() {
-    let temp_dir = TempDir::new().unwrap();
-    let base_path = temp_dir.path().to_path_buf();
+  let temp_dir = TempDir::new().unwrap();
+  let base_path = temp_dir.path().to_path_buf();
 
-    // Node 1: Create record and delete it
-    let mut config = PersistConfig::default();
-    config.snapshot_format = SnapshotFormat::MessagePack;
-    config.enable_incremental_snapshots = true;
-    config.snapshot_threshold = 3;
-    config.full_snapshot_interval = 10;
+  // Node 1: Create record and delete it
+  let mut config = PersistConfig::default();
+  config.snapshot_format = SnapshotFormat::MessagePack;
+  config.enable_incremental_snapshots = true;
+  config.snapshot_threshold = 3;
+  config.full_snapshot_interval = 10;
 
-    let mut node1 = PersistedCRDT::<String, String, String>::open(
-        base_path.clone(),
-        1, // node_id = 1
-        config.clone(),
+  let mut node1 = PersistedCRDT::<String, String, String>::open(
+    base_path.clone(),
+    1, // node_id = 1
+    config.clone(),
+  )
+  .unwrap();
+
+  // Create initial records to trigger full snapshot
+  node1
+    .insert_or_update(
+      &"user0".to_string(),
+      [("name".to_string(), "Alice".to_string())].into_iter(),
+    )
+    .unwrap();
+  node1
+    .insert_or_update(
+      &"user1".to_string(),
+      [("name".to_string(), "Bob".to_string())].into_iter(),
+    )
+    .unwrap();
+  node1
+    .insert_or_update(
+      &"user2".to_string(),
+      [("name".to_string(), "Charlie".to_string())].into_iter(),
     )
     .unwrap();
 
-    // Create initial records to trigger full snapshot
-    node1
-        .insert_or_update(
-            &"user0".to_string(),
-            [("name".to_string(), "Alice".to_string())].into_iter(),
-        )
-        .unwrap();
-    node1
-        .insert_or_update(
-            &"user1".to_string(),
-            [("name".to_string(), "Bob".to_string())].into_iter(),
-        )
-        .unwrap();
-    node1
-        .insert_or_update(
-            &"user2".to_string(),
-            [("name".to_string(), "Charlie".to_string())].into_iter(),
-        )
-        .unwrap();
+  // Full snapshot should have been created
+  let full_snapshots: Vec<_> = std::fs::read_dir(&base_path)
+    .unwrap()
+    .filter_map(|e| e.ok())
+    .filter(|e| {
+      e.file_name()
+        .to_string_lossy()
+        .starts_with("snapshot_full_")
+    })
+    .collect();
+  assert_eq!(full_snapshots.len(), 1, "Should have 1 full snapshot");
 
-    // Full snapshot should have been created
-    let full_snapshots: Vec<_> = std::fs::read_dir(&base_path)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.file_name()
-                .to_string_lossy()
-                .starts_with("snapshot_full_")
-        })
-        .collect();
-    assert_eq!(full_snapshots.len(), 1, "Should have 1 full snapshot");
+  // Delete user1 on node 1 (creates tombstone with node_id=1)
+  node1.delete_record(&"user1".to_string()).unwrap();
 
-    // Delete user1 on node 1 (creates tombstone with node_id=1)
-    node1.delete_record(&"user1".to_string()).unwrap();
-
-    // Trigger incremental snapshot
-    node1
-        .insert_or_update(
-            &"user3".to_string(),
-            [("name".to_string(), "Dave".to_string())].into_iter(),
-        )
-        .unwrap();
-    node1
-        .insert_or_update(
-            &"user4".to_string(),
-            [("name".to_string(), "Eve".to_string())].into_iter(),
-        )
-        .unwrap();
-
-    // Incremental snapshot should now exist
-    let incr_snapshots: Vec<_> = std::fs::read_dir(&base_path)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.file_name()
-                .to_string_lossy()
-                .starts_with("snapshot_incr_")
-        })
-        .collect();
-    assert!(
-        incr_snapshots.len() >= 1,
-        "Should have at least 1 incremental snapshot"
-    );
-
-    // Get the tombstone info from node1
-    let user1_tombstone = node1.crdt().get_tombstone(&"user1".to_string());
-    assert!(user1_tombstone.is_some(), "user1 should be tombstoned");
-    let original_node_id = user1_tombstone.unwrap().node_id;
-    assert_eq!(
-        original_node_id, 1,
-        "Original tombstone should have node_id=1"
-    );
-
-    drop(node1);
-
-    // Node 2: Recover from snapshots
-    let node2 = PersistedCRDT::<String, String, String>::open(
-        base_path.clone(),
-        2, // Different node_id
-        config,
+  // Trigger incremental snapshot
+  node1
+    .insert_or_update(
+      &"user3".to_string(),
+      [("name".to_string(), "Dave".to_string())].into_iter(),
+    )
+    .unwrap();
+  node1
+    .insert_or_update(
+      &"user4".to_string(),
+      [("name".to_string(), "Eve".to_string())].into_iter(),
     )
     .unwrap();
 
-    // Verify user1 is still tombstoned on node2
-    let recovered_tombstone = node2.crdt().get_tombstone(&"user1".to_string());
-    assert!(
-        recovered_tombstone.is_some(),
-        "user1 tombstone should be recovered on node2"
-    );
+  // Incremental snapshot should now exist
+  let incr_snapshots: Vec<_> = std::fs::read_dir(&base_path)
+    .unwrap()
+    .filter_map(|e| e.ok())
+    .filter(|e| {
+      e.file_name()
+        .to_string_lossy()
+        .starts_with("snapshot_incr_")
+    })
+    .collect();
+  assert!(
+    incr_snapshots.len() >= 1,
+    "Should have at least 1 incremental snapshot"
+  );
 
-    // CRITICAL ASSERTION: Tombstone should still have node_id=1 (not node_id=2)
-    let recovered_node_id = recovered_tombstone.unwrap().node_id;
-    assert_eq!(
-        recovered_node_id, original_node_id,
-        "Tombstone node_id should be preserved (should be 1, not 2)"
-    );
+  // Get the tombstone info from node1
+  let user1_tombstone = node1.crdt().get_tombstone(&"user1".to_string());
+  assert!(user1_tombstone.is_some(), "user1 should be tombstoned");
+  let original_node_id = user1_tombstone.unwrap().node_id;
+  assert_eq!(
+    original_node_id, 1,
+    "Original tombstone should have node_id=1"
+  );
 
-    // Verify other records were recovered correctly
-    let user0 = node2.crdt().get_record(&"user0".to_string());
-    assert!(user0.is_some(), "user0 should exist");
+  drop(node1);
 
-    let user2 = node2.crdt().get_record(&"user2".to_string());
-    assert!(user2.is_some(), "user2 should exist");
+  // Node 2: Recover from snapshots
+  let node2 = PersistedCRDT::<String, String, String>::open(
+    base_path.clone(),
+    2, // Different node_id
+    config,
+  )
+  .unwrap();
 
-    let user3 = node2.crdt().get_record(&"user3".to_string());
-    assert!(user3.is_some(), "user3 should exist");
+  // Verify user1 is still tombstoned on node2
+  let recovered_tombstone = node2.crdt().get_tombstone(&"user1".to_string());
+  assert!(
+    recovered_tombstone.is_some(),
+    "user1 tombstone should be recovered on node2"
+  );
+
+  // CRITICAL ASSERTION: Tombstone should still have node_id=1 (not node_id=2)
+  let recovered_node_id = recovered_tombstone.unwrap().node_id;
+  assert_eq!(
+    recovered_node_id, original_node_id,
+    "Tombstone node_id should be preserved (should be 1, not 2)"
+  );
+
+  // Verify other records were recovered correctly
+  let user0 = node2.crdt().get_record(&"user0".to_string());
+  assert!(user0.is_some(), "user0 should exist");
+
+  let user2 = node2.crdt().get_record(&"user2".to_string());
+  assert!(user2.is_some(), "user2 should exist");
+
+  let user3 = node2.crdt().get_record(&"user3".to_string());
+  assert!(user3.is_some(), "user3 should exist");
 }
 
 // ============================================================================
@@ -604,494 +579,521 @@ fn test_incremental_tombstone_preserves_node_id() {
 #[test]
 #[cfg(feature = "msgpack")]
 fn test_cleanup_msgpack_snapshots() {
-    use crdt_lite::persist::{PersistedCRDT, PersistConfig, SnapshotFormat};
+  use crdt_lite::persist::{PersistConfig, PersistedCRDT, SnapshotFormat};
 
-    let base_path = std::env::temp_dir().join("test_cleanup_msgpack");
-    let _ = std::fs::remove_dir_all(&base_path);
-    std::fs::create_dir_all(&base_path).unwrap();
+  let base_path = std::env::temp_dir().join("test_cleanup_msgpack");
+  let _ = std::fs::remove_dir_all(&base_path);
+  std::fs::create_dir_all(&base_path).unwrap();
 
-    let config = PersistConfig {
-        snapshot_threshold: 100,
-        snapshot_format: SnapshotFormat::MessagePack,
-        enable_incremental_snapshots: true,
-        full_snapshot_interval: 2,
-        auto_cleanup_snapshots: None, // Manual cleanup for testing
-        ..Default::default()
-    };
+  let config = PersistConfig {
+    snapshot_threshold: 100,
+    snapshot_format: SnapshotFormat::MessagePack,
+    enable_incremental_snapshots: true,
+    full_snapshot_interval: 2,
+    auto_cleanup_snapshots: None, // Manual cleanup for testing
+    ..Default::default()
+  };
 
-    let mut pcrdt = PersistedCRDT::<String, String, String>::open(
-        base_path.clone(),
-        1,
-        config,
-    )
-    .unwrap();
+  let mut pcrdt =
+    PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config).unwrap();
 
-    // Create multiple full + incremental snapshots
-    // First full + 2 incrementals
-    for i in 0..100 {
-        pcrdt.insert_or_update(
-            &format!("rec{}", i),
-            vec![("field".to_string(), format!("v1_{}", i))],
-        ).unwrap();
-    }
-    pcrdt.snapshot().unwrap(); // Full #1
+  // Create multiple full + incremental snapshots
+  // First full + 2 incrementals
+  for i in 0..100 {
+    pcrdt
+      .insert_or_update(
+        &format!("rec{}", i),
+        vec![("field".to_string(), format!("v1_{}", i))],
+      )
+      .unwrap();
+  }
+  pcrdt.snapshot().unwrap(); // Full #1
 
-    for i in 0..50 {
-        pcrdt.insert_or_update(
-            &format!("rec{}", i),
-            vec![("field".to_string(), format!("v2_{}", i))],
-        ).unwrap();
-    }
-    pcrdt.snapshot().unwrap(); // Incremental #2
+  for i in 0..50 {
+    pcrdt
+      .insert_or_update(
+        &format!("rec{}", i),
+        vec![("field".to_string(), format!("v2_{}", i))],
+      )
+      .unwrap();
+  }
+  pcrdt.snapshot().unwrap(); // Incremental #2
 
-    for i in 0..50 {
-        pcrdt.insert_or_update(
-            &format!("rec{}", i),
-            vec![("field".to_string(), format!("v3_{}", i))],
-        ).unwrap();
-    }
-    pcrdt.snapshot().unwrap(); // Full #3 (full_snapshot_interval: 2)
+  for i in 0..50 {
+    pcrdt
+      .insert_or_update(
+        &format!("rec{}", i),
+        vec![("field".to_string(), format!("v3_{}", i))],
+      )
+      .unwrap();
+  }
+  pcrdt.snapshot().unwrap(); // Full #3 (full_snapshot_interval: 2)
 
-    for i in 0..50 {
-        pcrdt.insert_or_update(
-            &format!("rec{}", i),
-            vec![("field".to_string(), format!("v4_{}", i))],
-        ).unwrap();
-    }
-    pcrdt.snapshot().unwrap(); // Incremental #4
+  for i in 0..50 {
+    pcrdt
+      .insert_or_update(
+        &format!("rec{}", i),
+        vec![("field".to_string(), format!("v4_{}", i))],
+      )
+      .unwrap();
+  }
+  pcrdt.snapshot().unwrap(); // Incremental #4
 
-    // Should have: full_1, incr_2, full_3, incr_4
-    let files: Vec<_> = std::fs::read_dir(&base_path)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .map(|e| e.file_name().to_string_lossy().to_string())
-        .filter(|f| f.starts_with("snapshot_"))
-        .collect();
+  // Should have: full_1, incr_2, full_3, incr_4
+  let files: Vec<_> = std::fs::read_dir(&base_path)
+    .unwrap()
+    .filter_map(|e| e.ok())
+    .map(|e| e.file_name().to_string_lossy().to_string())
+    .filter(|f| f.starts_with("snapshot_"))
+    .collect();
 
-    #[cfg(test)]
-    if std::env::var("RUST_LOG").is_ok() {
-        eprintln!("Snapshots before cleanup: {:?}", files);
-    }
+  #[cfg(test)]
+  if std::env::var("RUST_LOG").is_ok() {
+    eprintln!("Snapshots before cleanup: {:?}", files);
+  }
 
-    let full_count = files.iter().filter(|f| f.starts_with("snapshot_full_")).count();
-    let incr_count = files.iter().filter(|f| f.starts_with("snapshot_incr_")).count();
+  let full_count = files
+    .iter()
+    .filter(|f| f.starts_with("snapshot_full_"))
+    .count();
+  let incr_count = files
+    .iter()
+    .filter(|f| f.starts_with("snapshot_incr_"))
+    .count();
 
-    assert_eq!(full_count, 2, "Should have 2 full snapshots");
-    assert_eq!(incr_count, 2, "Should have 2 incremental snapshots");
+  assert_eq!(full_count, 2, "Should have 2 full snapshots");
+  assert_eq!(incr_count, 2, "Should have 2 incremental snapshots");
 
-    // Cleanup: keep only 1 full snapshot (the newest)
-    pcrdt.cleanup_old_snapshots(1, false).unwrap();
+  // Cleanup: keep only 1 full snapshot (the newest)
+  pcrdt.cleanup_old_snapshots(1, false).unwrap();
 
-    // Should now have: full_3, incr_4
-    // full_1 deleted → incr_2 should be orphaned and deleted
-    let files_after: Vec<_> = std::fs::read_dir(&base_path)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .map(|e| e.file_name().to_string_lossy().to_string())
-        .filter(|f| f.starts_with("snapshot_"))
-        .collect();
+  // Should now have: full_3, incr_4
+  // full_1 deleted → incr_2 should be orphaned and deleted
+  let files_after: Vec<_> = std::fs::read_dir(&base_path)
+    .unwrap()
+    .filter_map(|e| e.ok())
+    .map(|e| e.file_name().to_string_lossy().to_string())
+    .filter(|f| f.starts_with("snapshot_"))
+    .collect();
 
-    #[cfg(test)]
-    if std::env::var("RUST_LOG").is_ok() {
-        eprintln!("Snapshots after cleanup: {:?}", files_after);
-    }
+  #[cfg(test)]
+  if std::env::var("RUST_LOG").is_ok() {
+    eprintln!("Snapshots after cleanup: {:?}", files_after);
+  }
 
-    let full_after = files_after.iter().filter(|f| f.starts_with("snapshot_full_")).count();
-    let incr_after = files_after.iter().filter(|f| f.starts_with("snapshot_incr_")).count();
+  let full_after = files_after
+    .iter()
+    .filter(|f| f.starts_with("snapshot_full_"))
+    .count();
+  let incr_after = files_after
+    .iter()
+    .filter(|f| f.starts_with("snapshot_incr_"))
+    .count();
 
-    assert_eq!(full_after, 1, "Should have 1 full snapshot after cleanup");
+  assert_eq!(full_after, 1, "Should have 1 full snapshot after cleanup");
 
-    // The incremental might be deleted if it's superseded by a newer full snapshot
-    // Let's check if we have any incrementals, and if so, verify they build on the kept full
-    if incr_after > 0 {
-        let remaining_incr = files_after.iter()
-            .find(|f| f.starts_with("snapshot_incr_"))
-            .unwrap();
-        // Extract the kept full snapshot version
-        let kept_full_version = files_after.iter()
-            .find(|f| f.starts_with("snapshot_full_"))
-            .and_then(|f| f.strip_prefix("snapshot_full_"))
-            .and_then(|f| f.strip_suffix(".msgpack"))
-            .unwrap();
-        assert!(
-            remaining_incr.contains(&format!("_base_{}", kept_full_version)),
-            "Remaining incremental should build on kept full"
-        );
-    }
+  // The incremental might be deleted if it's superseded by a newer full snapshot
+  // Let's check if we have any incrementals, and if so, verify they build on the kept full
+  if incr_after > 0 {
+    let remaining_incr = files_after
+      .iter()
+      .find(|f| f.starts_with("snapshot_incr_"))
+      .unwrap();
+    // Extract the kept full snapshot version
+    let kept_full_version = files_after
+      .iter()
+      .find(|f| f.starts_with("snapshot_full_"))
+      .and_then(|f| f.strip_prefix("snapshot_full_"))
+      .and_then(|f| f.strip_suffix(".msgpack"))
+      .unwrap();
+    assert!(
+      remaining_incr.contains(&format!("_base_{}", kept_full_version)),
+      "Remaining incremental should build on kept full"
+    );
+  }
 
-    let _ = std::fs::remove_dir_all(&base_path);
+  let _ = std::fs::remove_dir_all(&base_path);
 }
 
 #[test]
 #[cfg(feature = "msgpack")]
 fn test_skip_empty_incrementals() {
-    use crdt_lite::persist::{PersistedCRDT, PersistConfig, SnapshotFormat};
-    use std::sync::{Arc, Mutex};
+  use crdt_lite::persist::{PersistConfig, PersistedCRDT, SnapshotFormat};
+  use std::sync::{Arc, Mutex};
 
-    let base_path = std::env::temp_dir().join("test_skip_empty");
-    let _ = std::fs::remove_dir_all(&base_path);
-    std::fs::create_dir_all(&base_path).unwrap();
+  let base_path = std::env::temp_dir().join("test_skip_empty");
+  let _ = std::fs::remove_dir_all(&base_path);
+  std::fs::create_dir_all(&base_path).unwrap();
 
-    let config = PersistConfig {
-        snapshot_threshold: 10,
-        snapshot_format: SnapshotFormat::MessagePack,
-        enable_incremental_snapshots: true,
-        skip_empty_incrementals: true, // Enable skip
-        ..Default::default()
-    };
+  let config = PersistConfig {
+    snapshot_threshold: 10,
+    snapshot_format: SnapshotFormat::MessagePack,
+    enable_incremental_snapshots: true,
+    skip_empty_incrementals: true, // Enable skip
+    ..Default::default()
+  };
 
-    let mut pcrdt = PersistedCRDT::<String, String, String>::open(
-        base_path.clone(),
-        1,
-        config,
+  let mut pcrdt =
+    PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config).unwrap();
+
+  // Track snapshot hook calls
+  let hook_calls = Arc::new(Mutex::new(Vec::new()));
+  let hook_calls_clone = hook_calls.clone();
+
+  pcrdt.add_snapshot_hook(Box::new(move |path: &std::path::Path, version: u64| {
+    hook_calls_clone
+      .lock()
+      .unwrap()
+      .push((path.to_path_buf(), version));
+  }));
+
+  // Create initial data and snapshot
+  for i in 0..10 {
+    pcrdt
+      .insert_or_update(
+        &format!("rec{}", i),
+        vec![("field".to_string(), format!("value{}", i))],
+      )
+      .unwrap();
+  }
+  pcrdt.snapshot().unwrap(); // Full snapshot
+
+  let initial_hook_calls = hook_calls.lock().unwrap().len();
+  assert_eq!(
+    initial_hook_calls, 1,
+    "Should have called hook for full snapshot"
+  );
+
+  // Count snapshot files before
+  let snapshots_before: Vec<_> = std::fs::read_dir(&base_path)
+    .unwrap()
+    .filter_map(|e| e.ok())
+    .filter(|e| e.file_name().to_string_lossy().starts_with("snapshot_"))
+    .collect();
+
+  // Try to snapshot with no changes (should skip)
+  pcrdt.snapshot().unwrap();
+
+  // Verify hook was NOT called for empty snapshot
+  let after_empty_calls = hook_calls.lock().unwrap().len();
+  assert_eq!(
+    after_empty_calls, initial_hook_calls,
+    "Hook should NOT be called for skipped snapshot"
+  );
+
+  // Verify no new snapshot files were created
+  let snapshots_after: Vec<_> = std::fs::read_dir(&base_path)
+    .unwrap()
+    .filter_map(|e| e.ok())
+    .filter(|e| e.file_name().to_string_lossy().starts_with("snapshot_"))
+    .collect();
+  assert_eq!(
+    snapshots_after.len(),
+    snapshots_before.len(),
+    "Should not create new snapshot file when empty"
+  );
+
+  // Now make a change and snapshot again
+  pcrdt
+    .insert_or_update(
+      &"rec0".to_string(),
+      vec![("field".to_string(), "updated".to_string())],
     )
     .unwrap();
 
-    // Track snapshot hook calls
-    let hook_calls = Arc::new(Mutex::new(Vec::new()));
-    let hook_calls_clone = hook_calls.clone();
+  pcrdt.snapshot().unwrap(); // Should create new snapshot
 
-    pcrdt.add_snapshot_hook(Box::new(move |path: &std::path::Path, version: u64| {
-        hook_calls_clone.lock().unwrap().push((path.to_path_buf(), version));
-    }));
+  // Verify hook WAS called for non-empty snapshot
+  let after_real_calls = hook_calls.lock().unwrap().len();
+  assert_eq!(
+    after_real_calls,
+    initial_hook_calls + 1,
+    "Hook should be called for real snapshot"
+  );
 
-    // Create initial data and snapshot
-    for i in 0..10 {
-        pcrdt.insert_or_update(
-            &format!("rec{}", i),
-            vec![("field".to_string(), format!("value{}", i))],
-        ).unwrap();
-    }
-    pcrdt.snapshot().unwrap(); // Full snapshot
+  // Test with skip_empty_incrementals: false
+  let config_no_skip = PersistConfig {
+    snapshot_threshold: 10,
+    snapshot_format: SnapshotFormat::MessagePack,
+    enable_incremental_snapshots: true,
+    skip_empty_incrementals: false, // Disable skip
+    ..Default::default()
+  };
 
-    let initial_hook_calls = hook_calls.lock().unwrap().len();
-    assert_eq!(initial_hook_calls, 1, "Should have called hook for full snapshot");
+  let base_path2 = std::env::temp_dir().join("test_no_skip_empty");
+  let _ = std::fs::remove_dir_all(&base_path2);
+  std::fs::create_dir_all(&base_path2).unwrap();
 
-    // Count snapshot files before
-    let snapshots_before: Vec<_> = std::fs::read_dir(&base_path)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_name().to_string_lossy().starts_with("snapshot_"))
-        .collect();
+  let mut pcrdt2 =
+    PersistedCRDT::<String, String, String>::open(base_path2.clone(), 1, config_no_skip).unwrap();
 
-    // Try to snapshot with no changes (should skip)
-    pcrdt.snapshot().unwrap();
-
-    // Verify hook was NOT called for empty snapshot
-    let after_empty_calls = hook_calls.lock().unwrap().len();
-    assert_eq!(after_empty_calls, initial_hook_calls, "Hook should NOT be called for skipped snapshot");
-
-    // Verify no new snapshot files were created
-    let snapshots_after: Vec<_> = std::fs::read_dir(&base_path)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_name().to_string_lossy().starts_with("snapshot_"))
-        .collect();
-    assert_eq!(snapshots_after.len(), snapshots_before.len(), "Should not create new snapshot file when empty");
-
-    // Now make a change and snapshot again
-    pcrdt.insert_or_update(
-        &"rec0".to_string(),
-        vec![("field".to_string(), "updated".to_string())],
-    ).unwrap();
-
-    pcrdt.snapshot().unwrap(); // Should create new snapshot
-
-    // Verify hook WAS called for non-empty snapshot
-    let after_real_calls = hook_calls.lock().unwrap().len();
-    assert_eq!(after_real_calls, initial_hook_calls + 1, "Hook should be called for real snapshot");
-
-    // Test with skip_empty_incrementals: false
-    let config_no_skip = PersistConfig {
-        snapshot_threshold: 10,
-        snapshot_format: SnapshotFormat::MessagePack,
-        enable_incremental_snapshots: true,
-        skip_empty_incrementals: false, // Disable skip
-        ..Default::default()
-    };
-
-    let base_path2 = std::env::temp_dir().join("test_no_skip_empty");
-    let _ = std::fs::remove_dir_all(&base_path2);
-    std::fs::create_dir_all(&base_path2).unwrap();
-
-    let mut pcrdt2 = PersistedCRDT::<String, String, String>::open(
-        base_path2.clone(),
-        1,
-        config_no_skip,
+  // Create initial data and snapshot
+  pcrdt2
+    .insert_or_update(
+      &"rec".to_string(),
+      vec![("field".to_string(), "value".to_string())],
     )
     .unwrap();
+  pcrdt2.snapshot().unwrap();
 
-    // Create initial data and snapshot
-    pcrdt2.insert_or_update(
-        &"rec".to_string(),
-        vec![("field".to_string(), "value".to_string())],
-    ).unwrap();
-    pcrdt2.snapshot().unwrap();
+  // Count snapshots before
+  let snapshots_before2: Vec<_> = std::fs::read_dir(&base_path2)
+    .unwrap()
+    .filter_map(|e| e.ok())
+    .filter(|e| e.file_name().to_string_lossy().starts_with("snapshot_"))
+    .collect();
 
-    // Count snapshots before
-    let snapshots_before2: Vec<_> = std::fs::read_dir(&base_path2)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_name().to_string_lossy().starts_with("snapshot_"))
-        .collect();
+  // Try to snapshot with no changes (should create empty snapshot when skip disabled)
+  pcrdt2.snapshot().unwrap();
 
-    // Try to snapshot with no changes (should create empty snapshot when skip disabled)
-    pcrdt2.snapshot().unwrap();
+  // Verify a new snapshot was created (even though empty)
+  let snapshots_after2: Vec<_> = std::fs::read_dir(&base_path2)
+    .unwrap()
+    .filter_map(|e| e.ok())
+    .filter(|e| e.file_name().to_string_lossy().starts_with("snapshot_"))
+    .collect();
+  assert!(
+    snapshots_after2.len() > snapshots_before2.len(),
+    "Should create new snapshot even when empty (skip disabled)"
+  );
 
-    // Verify a new snapshot was created (even though empty)
-    let snapshots_after2: Vec<_> = std::fs::read_dir(&base_path2)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_name().to_string_lossy().starts_with("snapshot_"))
-        .collect();
-    assert!(
-        snapshots_after2.len() > snapshots_before2.len(),
-        "Should create new snapshot even when empty (skip disabled)"
-    );
-
-    let _ = std::fs::remove_dir_all(&base_path);
-    let _ = std::fs::remove_dir_all(&base_path2);
+  let _ = std::fs::remove_dir_all(&base_path);
+  let _ = std::fs::remove_dir_all(&base_path2);
 }
 
 #[test]
 #[cfg(feature = "msgpack")]
 fn test_schema_evolution() {
-    use crdt_lite::persist::{PersistedCRDT, PersistConfig, SnapshotFormat};
+  use crdt_lite::persist::{PersistConfig, PersistedCRDT, SnapshotFormat};
 
-    // This test demonstrates MessagePack's schema evolution capability:
-    // MessagePack uses self-describing format that allows loading snapshots
-    // even when the struct definition has changed (new fields added with #[serde(default)])
-    //
-    // Compare to bincode:
-    // - Bincode: length-prefixed encoding that hardcodes field count → breaks on schema changes
-    // - MessagePack: self-describing format → missing fields use Default::default()
-    //
-    // Real-world scenario:
-    // 1. v0.5.0: CRDT has fields A, B
-    // 2. v0.6.0: CRDT adds field C with #[serde(default)]
-    // 3. MessagePack snapshots from v0.5.0 load fine in v0.6.0 (C gets default)
-    // 4. Bincode snapshots from v0.5.0 FAIL to load in v0.6.0 (field count mismatch)
+  // This test demonstrates MessagePack's schema evolution capability:
+  // MessagePack uses self-describing format that allows loading snapshots
+  // even when the struct definition has changed (new fields added with #[serde(default)])
+  //
+  // Compare to bincode:
+  // - Bincode: length-prefixed encoding that hardcodes field count → breaks on schema changes
+  // - MessagePack: self-describing format → missing fields use Default::default()
+  //
+  // Real-world scenario:
+  // 1. v0.5.0: CRDT has fields A, B
+  // 2. v0.6.0: CRDT adds field C with #[serde(default)]
+  // 3. MessagePack snapshots from v0.5.0 load fine in v0.6.0 (C gets default)
+  // 4. Bincode snapshots from v0.5.0 FAIL to load in v0.6.0 (field count mismatch)
 
-    let base_path = std::env::temp_dir().join("test_schema_evolution");
-    let _ = std::fs::remove_dir_all(&base_path);
-    std::fs::create_dir_all(&base_path).unwrap();
+  let base_path = std::env::temp_dir().join("test_schema_evolution");
+  let _ = std::fs::remove_dir_all(&base_path);
+  std::fs::create_dir_all(&base_path).unwrap();
 
-    let config = PersistConfig {
-        snapshot_threshold: 10,
-        snapshot_format: SnapshotFormat::MessagePack,
-        enable_incremental_snapshots: false,
-        ..Default::default()
-    };
+  let config = PersistConfig {
+    snapshot_threshold: 10,
+    snapshot_format: SnapshotFormat::MessagePack,
+    enable_incremental_snapshots: false,
+    ..Default::default()
+  };
 
-    // Create a CRDT, add data, and snapshot
-    let mut pcrdt = PersistedCRDT::<String, String, String>::open(
-        base_path.clone(),
-        1,
-        config.clone(),
-    )
-    .unwrap();
+  // Create a CRDT, add data, and snapshot
+  let mut pcrdt =
+    PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config.clone()).unwrap();
 
-    for i in 0..10 {
-        pcrdt.insert_or_update(
-            &format!("user{}", i),
-            vec![
-                ("name".to_string(), format!("User{}", i)),
-                ("age".to_string(), format!("{}", 20 + i)),
-            ],
-        ).unwrap();
-    }
+  for i in 0..10 {
+    pcrdt
+      .insert_or_update(
+        &format!("user{}", i),
+        vec![
+          ("name".to_string(), format!("User{}", i)),
+          ("age".to_string(), format!("{}", 20 + i)),
+        ],
+      )
+      .unwrap();
+  }
 
-    pcrdt.snapshot().unwrap();
-    drop(pcrdt);
+  pcrdt.snapshot().unwrap();
+  drop(pcrdt);
 
-    // Reopen - simulates loading snapshot after code changes
-    // In real scenario, new code might have new fields with #[serde(default)]
-    // MessagePack handles this gracefully
-    let pcrdt = PersistedCRDT::<String, String, String>::open(
-        base_path.clone(),
-        1,
-        config,
-    )
-    .unwrap();
+  // Reopen - simulates loading snapshot after code changes
+  // In real scenario, new code might have new fields with #[serde(default)]
+  // MessagePack handles this gracefully
+  let pcrdt = PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config).unwrap();
 
-    // Verify all data loaded correctly
-    for i in 0..10 {
-        let record = pcrdt.crdt().get_record(&format!("user{}", i)).unwrap();
-        assert_eq!(record.fields.get("name").unwrap(), &format!("User{}", i));
-        assert_eq!(record.fields.get("age").unwrap(), &format!("{}", 20 + i));
-    }
+  // Verify all data loaded correctly
+  for i in 0..10 {
+    let record = pcrdt.crdt().get_record(&format!("user{}", i)).unwrap();
+    assert_eq!(record.fields.get("name").unwrap(), &format!("User{}", i));
+    assert_eq!(record.fields.get("age").unwrap(), &format!("{}", 20 + i));
+  }
 
-    // The key insight: MessagePack's flexibility allows snapshots to survive
-    // code changes that add new fields. Bincode would fail here if we added
-    // new fields to the CRDT struct with #[serde(default)].
-    //
-    // This is why we recommend persist-msgpack over persist (bincode) for
-    // production use - it provides upgrade path without losing data.
+  // The key insight: MessagePack's flexibility allows snapshots to survive
+  // code changes that add new fields. Bincode would fail here if we added
+  // new fields to the CRDT struct with #[serde(default)].
+  //
+  // This is why we recommend persist-msgpack over persist (bincode) for
+  // production use - it provides upgrade path without losing data.
 
-    let _ = std::fs::remove_dir_all(&base_path);
+  let _ = std::fs::remove_dir_all(&base_path);
 }
 
 #[test]
 #[cfg(feature = "msgpack")]
 fn test_schema_evolution_add_fields() {
-    use serde::{Deserialize, Serialize};
+  use serde::{Deserialize, Serialize};
 
-    // Simulate adding fields to a struct across versions
-    // This is the KEY test for schema evolution with MessagePack
+  // Simulate adding fields to a struct across versions
+  // This is the KEY test for schema evolution with MessagePack
 
-    // Version 1: Original struct with 2 fields
-    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-    struct UserV1 {
-        name: String,
-        age: u32,
-    }
+  // Version 1: Original struct with 2 fields
+  #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+  struct UserV1 {
+    name: String,
+    age: u32,
+  }
 
-    // Version 2: New struct with 4 fields (2 new fields with defaults)
-    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-    struct UserV2 {
-        name: String,
-        age: u32,
-        #[serde(default)]
-        email: String,  // New field - defaults to ""
-        #[serde(default)]
-        premium: bool,  // New field - defaults to false
-    }
+  // Version 2: New struct with 4 fields (2 new fields with defaults)
+  #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+  struct UserV2 {
+    name: String,
+    age: u32,
+    #[serde(default)]
+    email: String, // New field - defaults to ""
+    #[serde(default)]
+    premium: bool, // New field - defaults to false
+  }
 
-    let base_path = std::env::temp_dir().join("test_schema_evolution_add_fields");
-    let _ = std::fs::remove_dir_all(&base_path);
-    std::fs::create_dir_all(&base_path).unwrap();
+  let base_path = std::env::temp_dir().join("test_schema_evolution_add_fields");
+  let _ = std::fs::remove_dir_all(&base_path);
+  std::fs::create_dir_all(&base_path).unwrap();
 
-    // Phase 1: Write data with V1 schema (2 fields)
-    {
-        let old_user = UserV1 {
-            name: "Alice".to_string(),
-            age: 30,
-        };
+  // Phase 1: Write data with V1 schema (2 fields)
+  {
+    let old_user = UserV1 {
+      name: "Alice".to_string(),
+      age: 30,
+    };
 
-        // Serialize to MessagePack
-        let msgpack_bytes = rmp_serde::to_vec(&old_user).unwrap();
+    // Serialize to MessagePack
+    let msgpack_bytes = rmp_serde::to_vec(&old_user).unwrap();
 
-        // Write directly to snapshot file to simulate old version
-        // We'll create a minimal CRDT snapshot structure
-        let snapshot_path = base_path.join("user_v1.msgpack");
-        std::fs::write(&snapshot_path, msgpack_bytes).unwrap();
-    }
+    // Write directly to snapshot file to simulate old version
+    // We'll create a minimal CRDT snapshot structure
+    let snapshot_path = base_path.join("user_v1.msgpack");
+    std::fs::write(&snapshot_path, msgpack_bytes).unwrap();
+  }
 
-    // Phase 2: Read data with V2 schema (4 fields)
-    {
-        let snapshot_path = base_path.join("user_v1.msgpack");
-        let msgpack_bytes = std::fs::read(&snapshot_path).unwrap();
+  // Phase 2: Read data with V2 schema (4 fields)
+  {
+    let snapshot_path = base_path.join("user_v1.msgpack");
+    let msgpack_bytes = std::fs::read(&snapshot_path).unwrap();
 
-        // Deserialize with NEW struct that has more fields
-        let new_user: UserV2 = rmp_serde::from_slice(&msgpack_bytes).unwrap();
+    // Deserialize with NEW struct that has more fields
+    let new_user: UserV2 = rmp_serde::from_slice(&msgpack_bytes).unwrap();
 
-        // Verify old fields preserved
-        assert_eq!(new_user.name, "Alice");
-        assert_eq!(new_user.age, 30);
+    // Verify old fields preserved
+    assert_eq!(new_user.name, "Alice");
+    assert_eq!(new_user.age, 30);
 
-        // Verify new fields have defaults
-        assert_eq!(new_user.email, "", "New field should default to empty string");
-        assert_eq!(new_user.premium, false, "New field should default to false");
+    // Verify new fields have defaults
+    assert_eq!(
+      new_user.email, "",
+      "New field should default to empty string"
+    );
+    assert_eq!(new_user.premium, false, "New field should default to false");
 
-        // This is the magic of MessagePack schema evolution!
-        // Old snapshot with 2 fields loads fine into struct with 4 fields.
-        // Missing fields get their #[serde(default)] values.
-    }
+    // This is the magic of MessagePack schema evolution!
+    // Old snapshot with 2 fields loads fine into struct with 4 fields.
+    // Missing fields get their #[serde(default)] values.
+  }
 
-    // Phase 3: Demonstrate bincode would FAIL this test
-    // (Commented out, but this is what would happen)
-    /*
-    {
-        let old_user = UserV1 { name: "Alice".to_string(), age: 30 };
-        let bincode_bytes = bincode::encode_to_vec(&old_user, bincode::config::standard()).unwrap();
+  // Phase 3: Demonstrate bincode would FAIL this test
+  // (Commented out, but this is what would happen)
+  /*
+  {
+      let old_user = UserV1 { name: "Alice".to_string(), age: 30 };
+      let bincode_bytes = bincode::encode_to_vec(&old_user, bincode::config::standard()).unwrap();
 
-        // This would PANIC with bincode:
-        // "invalid type: found 2 fields, expected struct UserV2 with 4 fields"
-        // let new_user: UserV2 = bincode::decode_from_slice(&bincode_bytes, bincode::config::standard()).unwrap();
-    }
-    */
+      // This would PANIC with bincode:
+      // "invalid type: found 2 fields, expected struct UserV2 with 4 fields"
+      // let new_user: UserV2 = bincode::decode_from_slice(&bincode_bytes, bincode::config::standard()).unwrap();
+  }
+  */
 
-    let _ = std::fs::remove_dir_all(&base_path);
+  let _ = std::fs::remove_dir_all(&base_path);
 }
 
 #[test]
 #[cfg(feature = "msgpack")]
 fn test_corrupted_snapshot_recovery() {
-    use crdt_lite::persist::{PersistedCRDT, PersistConfig, SnapshotFormat};
-    use std::io::Write;
+  use crdt_lite::persist::{PersistConfig, PersistedCRDT, SnapshotFormat};
+  use std::io::Write;
 
-    let base_path = std::env::temp_dir().join("test_corrupted_snapshot");
-    let _ = std::fs::remove_dir_all(&base_path);
-    std::fs::create_dir_all(&base_path).unwrap();
+  let base_path = std::env::temp_dir().join("test_corrupted_snapshot");
+  let _ = std::fs::remove_dir_all(&base_path);
+  std::fs::create_dir_all(&base_path).unwrap();
 
-    let config = PersistConfig {
-        snapshot_threshold: 10,
-        snapshot_format: SnapshotFormat::MessagePack,
-        enable_incremental_snapshots: false,
-        ..Default::default()
-    };
+  let config = PersistConfig {
+    snapshot_threshold: 10,
+    snapshot_format: SnapshotFormat::MessagePack,
+    enable_incremental_snapshots: false,
+    ..Default::default()
+  };
 
-    // Create initial snapshot
-    {
-        let mut pcrdt = PersistedCRDT::<String, String, String>::open(
-            base_path.clone(),
-            1,
-            config.clone(),
+  // Create initial snapshot
+  {
+    let mut pcrdt =
+      PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config.clone()).unwrap();
+
+    for i in 0..10 {
+      pcrdt
+        .insert_or_update(
+          &format!("rec{}", i),
+          vec![("field".to_string(), format!("value{}", i))],
         )
         .unwrap();
-
-        for i in 0..10 {
-            pcrdt.insert_or_update(
-                &format!("rec{}", i),
-                vec![("field".to_string(), format!("value{}", i))],
-            ).unwrap();
-        }
-
-        pcrdt.snapshot().unwrap();
     }
 
-    // Find the snapshot file and corrupt it
-    let snapshot_file: std::path::PathBuf = std::fs::read_dir(&base_path)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .find(|e| e.file_name().to_string_lossy().starts_with("snapshot_full_"))
-        .map(|e| e.path())
-        .unwrap();
+    pcrdt.snapshot().unwrap();
+  }
 
-    // Corrupt the snapshot by writing garbage
-    {
-        let mut file = std::fs::OpenOptions::new()
-            .write(true)
-            .truncate(true)
-            .open(&snapshot_file)
-            .unwrap();
-        file.write_all(b"CORRUPTED GARBAGE DATA").unwrap();
+  // Find the snapshot file and corrupt it
+  let snapshot_file: std::path::PathBuf = std::fs::read_dir(&base_path)
+    .unwrap()
+    .filter_map(|e| e.ok())
+    .find(|e| {
+      e.file_name()
+        .to_string_lossy()
+        .starts_with("snapshot_full_")
+    })
+    .map(|e| e.path())
+    .unwrap();
+
+  // Corrupt the snapshot by writing garbage
+  {
+    let mut file = std::fs::OpenOptions::new()
+      .write(true)
+      .truncate(true)
+      .open(&snapshot_file)
+      .unwrap();
+    file.write_all(b"CORRUPTED GARBAGE DATA").unwrap();
+  }
+
+  // Try to recover - should fail gracefully or fall back to WAL
+  let result = PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config);
+
+  // With corrupted snapshot and no WAL, recovery should either:
+  // 1. Fail with an error (acceptable - corruption detected)
+  // 2. Start with empty CRDT (also acceptable - no valid snapshot + no WAL)
+  match result {
+    Ok(_pcrdt) => {
+      // Recovered with empty state (no snapshot + no WAL)
+      // This is acceptable behavior - corruption was handled gracefully
+      // We can't easily verify it's truly empty from public API,
+      // but the fact that it recovered without panic is good enough
     }
-
-    // Try to recover - should fail gracefully or fall back to WAL
-    let result = PersistedCRDT::<String, String, String>::open(
-        base_path.clone(),
-        1,
-        config,
-    );
-
-    // With corrupted snapshot and no WAL, recovery should either:
-    // 1. Fail with an error (acceptable - corruption detected)
-    // 2. Start with empty CRDT (also acceptable - no valid snapshot + no WAL)
-    match result {
-        Ok(_pcrdt) => {
-            // Recovered with empty state (no snapshot + no WAL)
-            // This is acceptable behavior - corruption was handled gracefully
-            // We can't easily verify it's truly empty from public API,
-            // but the fact that it recovered without panic is good enough
-        }
-        Err(_) => {
-            // Failed to recover - also acceptable (corruption detected)
-            // This is the current behavior
-        }
+    Err(_) => {
+      // Failed to recover - also acceptable (corruption detected)
+      // This is the current behavior
     }
+  }
 
-    let _ = std::fs::remove_dir_all(&base_path);
+  let _ = std::fs::remove_dir_all(&base_path);
 }
 
 // ============================================================================
@@ -1101,320 +1103,358 @@ fn test_corrupted_snapshot_recovery() {
 #[test]
 #[cfg(feature = "msgpack")]
 fn test_snapshot_hook() {
-    use crdt_lite::persist::{PersistedCRDT, PersistConfig, SnapshotFormat};
-    use std::sync::{Arc, Mutex};
+  use crdt_lite::persist::{PersistConfig, PersistedCRDT, SnapshotFormat};
+  use std::sync::{Arc, Mutex};
 
-    let base_path = std::env::temp_dir().join("test_snapshot_hook");
-    let _ = std::fs::remove_dir_all(&base_path);
-    std::fs::create_dir_all(&base_path).unwrap();
+  let base_path = std::env::temp_dir().join("test_snapshot_hook");
+  let _ = std::fs::remove_dir_all(&base_path);
+  std::fs::create_dir_all(&base_path).unwrap();
 
-    let config = PersistConfig {
-        snapshot_threshold: 10,
-        snapshot_format: SnapshotFormat::MessagePack,
-        enable_incremental_snapshots: true,
-        full_snapshot_interval: 1, // Create full after each incremental
-        ..Default::default()
-    };
+  let config = PersistConfig {
+    snapshot_threshold: 10,
+    snapshot_format: SnapshotFormat::MessagePack,
+    enable_incremental_snapshots: true,
+    full_snapshot_interval: 1, // Create full after each incremental
+    ..Default::default()
+  };
 
-    let mut pcrdt = PersistedCRDT::<String, String, String>::open(
-        base_path.clone(),
-        1,
-        config,
-    )
-    .unwrap();
+  let mut pcrdt =
+    PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config).unwrap();
 
-    // Track hook invocations
-    let hook_data = Arc::new(Mutex::new(Vec::new()));
-    let hook_data_clone = hook_data.clone();
+  // Track hook invocations
+  let hook_data = Arc::new(Mutex::new(Vec::new()));
+  let hook_data_clone = hook_data.clone();
 
-    pcrdt.add_snapshot_hook(Box::new(move |path: &std::path::Path, db_version: u64| {
-        let filename = path.file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("")
-            .to_string();
-        hook_data_clone.lock().unwrap().push((filename, db_version));
-    }));
+  pcrdt.add_snapshot_hook(Box::new(move |path: &std::path::Path, db_version: u64| {
+    let filename = path
+      .file_name()
+      .and_then(|n| n.to_str())
+      .unwrap_or("")
+      .to_string();
+    hook_data_clone.lock().unwrap().push((filename, db_version));
+  }));
 
-    // Create data and trigger snapshots
-    for i in 0..10 {
-        pcrdt.insert_or_update(
-            &format!("rec{}", i),
-            vec![("field".to_string(), format!("value{}", i))],
-        ).unwrap();
-    }
-    let db_version_1 = pcrdt.get_clock_time();
-    pcrdt.snapshot().unwrap(); // Full snapshot #1
+  // Create data and trigger snapshots
+  for i in 0..10 {
+    pcrdt
+      .insert_or_update(
+        &format!("rec{}", i),
+        vec![("field".to_string(), format!("value{}", i))],
+      )
+      .unwrap();
+  }
+  let db_version_1 = pcrdt.get_clock_time();
+  pcrdt.snapshot().unwrap(); // Full snapshot #1
 
-    for i in 0..5 {
-        pcrdt.insert_or_update(
-            &format!("rec{}", i),
-            vec![("field".to_string(), format!("updated{}", i))],
-        ).unwrap();
-    }
-    let db_version_2 = pcrdt.get_clock_time();
-    pcrdt.snapshot().unwrap(); // Incremental #2
+  for i in 0..5 {
+    pcrdt
+      .insert_or_update(
+        &format!("rec{}", i),
+        vec![("field".to_string(), format!("updated{}", i))],
+      )
+      .unwrap();
+  }
+  let db_version_2 = pcrdt.get_clock_time();
+  pcrdt.snapshot().unwrap(); // Incremental #2
 
-    for i in 0..5 {
-        pcrdt.insert_or_update(
-            &format!("rec{}", i),
-            vec![("field".to_string(), format!("updated2_{}", i))],
-        ).unwrap();
-    }
-    let db_version_3 = pcrdt.get_clock_time();
-    pcrdt.snapshot().unwrap(); // Full snapshot #3 (interval: 2)
+  for i in 0..5 {
+    pcrdt
+      .insert_or_update(
+        &format!("rec{}", i),
+        vec![("field".to_string(), format!("updated2_{}", i))],
+      )
+      .unwrap();
+  }
+  let db_version_3 = pcrdt.get_clock_time();
+  pcrdt.snapshot().unwrap(); // Full snapshot #3 (interval: 2)
 
-    // Verify hook was called 3 times
-    let calls = hook_data.lock().unwrap();
-    assert_eq!(calls.len(), 3, "Hook should be called for each snapshot");
+  // Verify hook was called 3 times
+  let calls = hook_data.lock().unwrap();
+  assert_eq!(calls.len(), 3, "Hook should be called for each snapshot");
 
-    // Verify hook received correct filenames
-    assert!(calls[0].0.starts_with("snapshot_full_"), "First should be full snapshot");
-    assert!(calls[1].0.starts_with("snapshot_incr_"), "Second should be incremental");
-    assert!(calls[2].0.starts_with("snapshot_full_"), "Third should be full snapshot");
+  // Verify hook received correct filenames
+  assert!(
+    calls[0].0.starts_with("snapshot_full_"),
+    "First should be full snapshot"
+  );
+  assert!(
+    calls[1].0.starts_with("snapshot_incr_"),
+    "Second should be incremental"
+  );
+  assert!(
+    calls[2].0.starts_with("snapshot_full_"),
+    "Third should be full snapshot"
+  );
 
-    // Verify db_version parameters are reasonable
-    assert!(calls[0].1 > 0 && calls[0].1 <= db_version_1, "db_version should be reasonable");
-    assert!(calls[1].1 > calls[0].1 && calls[1].1 <= db_version_2, "db_version should increase");
-    assert!(calls[2].1 > calls[1].1 && calls[2].1 <= db_version_3, "db_version should increase");
+  // Verify db_version parameters are reasonable
+  assert!(
+    calls[0].1 > 0 && calls[0].1 <= db_version_1,
+    "db_version should be reasonable"
+  );
+  assert!(
+    calls[1].1 > calls[0].1 && calls[1].1 <= db_version_2,
+    "db_version should increase"
+  );
+  assert!(
+    calls[2].1 > calls[1].1 && calls[2].1 <= db_version_3,
+    "db_version should increase"
+  );
 
-    let _ = std::fs::remove_dir_all(&base_path);
+  let _ = std::fs::remove_dir_all(&base_path);
 }
 
 #[test]
 #[cfg(feature = "persist")]
 fn test_wal_segment_hook() {
-    use crdt_lite::persist::{PersistedCRDT, PersistConfig};
-    use std::sync::{Arc, Mutex};
+  use crdt_lite::persist::{PersistConfig, PersistedCRDT};
+  use std::sync::{Arc, Mutex};
 
-    let base_path = std::env::temp_dir().join("test_wal_segment_hook");
-    let _ = std::fs::remove_dir_all(&base_path);
-    std::fs::create_dir_all(&base_path).unwrap();
+  let base_path = std::env::temp_dir().join("test_wal_segment_hook");
+  let _ = std::fs::remove_dir_all(&base_path);
+  std::fs::create_dir_all(&base_path).unwrap();
 
-    let config = PersistConfig {
-        snapshot_threshold: 50, // Force WAL rotation by snapshotting
-        ..Default::default()
-    };
+  let config = PersistConfig {
+    snapshot_threshold: 50, // Force WAL rotation by snapshotting
+    ..Default::default()
+  };
 
-    let mut pcrdt = PersistedCRDT::<String, String, String>::open(
-        base_path.clone(),
-        1,
-        config,
-    )
-    .unwrap();
+  let mut pcrdt =
+    PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config).unwrap();
 
-    // Track WAL segment hook invocations
-    let sealed_segments = Arc::new(Mutex::new(Vec::new()));
-    let sealed_clone = sealed_segments.clone();
+  // Track WAL segment hook invocations
+  let sealed_segments = Arc::new(Mutex::new(Vec::new()));
+  let sealed_clone = sealed_segments.clone();
 
-    pcrdt.add_wal_segment_hook(Box::new(move |path: &std::path::Path| {
-        let filename = path.file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("")
-            .to_string();
-        sealed_clone.lock().unwrap().push(filename);
-    }));
+  pcrdt.add_wal_segment_hook(Box::new(move |path: &std::path::Path| {
+    let filename = path
+      .file_name()
+      .and_then(|n| n.to_str())
+      .unwrap_or("")
+      .to_string();
+    sealed_clone.lock().unwrap().push(filename);
+  }));
 
-    // Write data and snapshot to rotate WAL
-    for i in 0..50 {
-        pcrdt.insert_or_update(
-            &format!("rec{}", i),
-            vec![("field".to_string(), format!("value{}", i))],
-        ).unwrap();
-    }
-    pcrdt.snapshot().unwrap(); // Should seal current WAL and start new one
+  // Write data and snapshot to rotate WAL
+  for i in 0..50 {
+    pcrdt
+      .insert_or_update(
+        &format!("rec{}", i),
+        vec![("field".to_string(), format!("value{}", i))],
+      )
+      .unwrap();
+  }
+  pcrdt.snapshot().unwrap(); // Should seal current WAL and start new one
 
-    // Write more data and snapshot again
-    for i in 50..100 {
-        pcrdt.insert_or_update(
-            &format!("rec{}", i),
-            vec![("field".to_string(), format!("value{}", i))],
-        ).unwrap();
-    }
-    pcrdt.snapshot().unwrap(); // Should seal second WAL
+  // Write more data and snapshot again
+  for i in 50..100 {
+    pcrdt
+      .insert_or_update(
+        &format!("rec{}", i),
+        vec![("field".to_string(), format!("value{}", i))],
+      )
+      .unwrap();
+  }
+  pcrdt.snapshot().unwrap(); // Should seal second WAL
 
-    // Verify hook was called for sealed segments
-    let sealed = sealed_segments.lock().unwrap();
-    assert!(sealed.len() >= 1, "Should have sealed at least 1 WAL segment");
+  // Verify hook was called for sealed segments
+  let sealed = sealed_segments.lock().unwrap();
+  assert!(
+    sealed.len() >= 1,
+    "Should have sealed at least 1 WAL segment"
+  );
 
-    // Verify sealed segment filenames are valid
-    for segment in sealed.iter() {
-        assert!(segment.starts_with("wal_"), "Sealed segment should be WAL file");
-        assert!(segment.ends_with(".bin"), "Sealed segment should have .bin extension");
-    }
+  // Verify sealed segment filenames are valid
+  for segment in sealed.iter() {
+    assert!(
+      segment.starts_with("wal_"),
+      "Sealed segment should be WAL file"
+    );
+    assert!(
+      segment.ends_with(".bin"),
+      "Sealed segment should have .bin extension"
+    );
+  }
 
-    let _ = std::fs::remove_dir_all(&base_path);
+  let _ = std::fs::remove_dir_all(&base_path);
 }
 
 #[test]
 #[cfg(feature = "msgpack")]
 fn test_upload_tracking() {
-    use crdt_lite::persist::{PersistedCRDT, PersistConfig, SnapshotFormat};
+  use crdt_lite::persist::{PersistConfig, PersistedCRDT, SnapshotFormat};
 
-    let base_path = std::env::temp_dir().join("test_upload_tracking");
-    let _ = std::fs::remove_dir_all(&base_path);
-    std::fs::create_dir_all(&base_path).unwrap();
+  let base_path = std::env::temp_dir().join("test_upload_tracking");
+  let _ = std::fs::remove_dir_all(&base_path);
+  std::fs::create_dir_all(&base_path).unwrap();
 
-    let config = PersistConfig {
-        snapshot_threshold: 10,
-        snapshot_format: SnapshotFormat::MessagePack,
-        enable_incremental_snapshots: true,
-        full_snapshot_interval: 2,
-        auto_cleanup_snapshots: None, // Manual cleanup
-        ..Default::default()
-    };
+  let config = PersistConfig {
+    snapshot_threshold: 10,
+    snapshot_format: SnapshotFormat::MessagePack,
+    enable_incremental_snapshots: true,
+    full_snapshot_interval: 2,
+    auto_cleanup_snapshots: None, // Manual cleanup
+    ..Default::default()
+  };
 
-    let mut pcrdt = PersistedCRDT::<String, String, String>::open(
-        base_path.clone(),
-        1,
-        config,
-    )
-    .unwrap();
+  let mut pcrdt =
+    PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config).unwrap();
 
-    // Create 3 snapshots
-    for round in 0..3 {
-        for i in 0..10 {
-            pcrdt.insert_or_update(
-                &format!("rec{}", i),
-                vec![("field".to_string(), format!("v{}_{}", round, i))],
-            ).unwrap();
-        }
-        pcrdt.snapshot().unwrap();
+  // Create 3 snapshots
+  for round in 0..3 {
+    for i in 0..10 {
+      pcrdt
+        .insert_or_update(
+          &format!("rec{}", i),
+          vec![("field".to_string(), format!("v{}_{}", round, i))],
+        )
+        .unwrap();
     }
+    pcrdt.snapshot().unwrap();
+  }
 
-    // Get all snapshot files
-    let snapshots: Vec<_> = std::fs::read_dir(&base_path)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_name().to_string_lossy().starts_with("snapshot_"))
-        .map(|e| e.path())
-        .collect();
+  // Get all snapshot files
+  let snapshots: Vec<_> = std::fs::read_dir(&base_path)
+    .unwrap()
+    .filter_map(|e| e.ok())
+    .filter(|e| e.file_name().to_string_lossy().starts_with("snapshot_"))
+    .map(|e| e.path())
+    .collect();
 
-    assert!(snapshots.len() >= 2, "Should have at least 2 snapshots");
+  assert!(snapshots.len() >= 2, "Should have at least 2 snapshots");
 
-    // Mark first snapshot as uploaded
-    pcrdt.mark_snapshot_uploaded(snapshots[0].clone());
+  // Mark first snapshot as uploaded
+  pcrdt.mark_snapshot_uploaded(snapshots[0].clone());
 
-    // Try cleanup with require_uploaded: true, keep 1
-    // Should only delete the uploaded snapshot
-    pcrdt.cleanup_old_snapshots(1, true).unwrap();
+  // Try cleanup with require_uploaded: true, keep 1
+  // Should only delete the uploaded snapshot
+  pcrdt.cleanup_old_snapshots(1, true).unwrap();
 
-    let remaining: Vec<_> = std::fs::read_dir(&base_path)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_name().to_string_lossy().starts_with("snapshot_"))
-        .collect();
+  let remaining: Vec<_> = std::fs::read_dir(&base_path)
+    .unwrap()
+    .filter_map(|e| e.ok())
+    .filter(|e| e.file_name().to_string_lossy().starts_with("snapshot_"))
+    .collect();
 
-    // Should have kept recent snapshots + deleted old uploaded ones
-    // Exact count depends on full vs incremental, but should be <= original
-    assert!(
-        remaining.len() <= snapshots.len(),
-        "Should have deleted some snapshots"
-    );
+  // Should have kept recent snapshots + deleted old uploaded ones
+  // Exact count depends on full vs incremental, but should be <= original
+  assert!(
+    remaining.len() <= snapshots.len(),
+    "Should have deleted some snapshots"
+  );
 
-    // Now mark ALL remaining as uploaded and cleanup with require_uploaded: false
-    for snapshot in &remaining {
-        pcrdt.mark_snapshot_uploaded(snapshot.path());
-    }
+  // Now mark ALL remaining as uploaded and cleanup with require_uploaded: false
+  for snapshot in &remaining {
+    pcrdt.mark_snapshot_uploaded(snapshot.path());
+  }
 
-    pcrdt.cleanup_old_snapshots(1, false).unwrap(); // Aggressive cleanup
+  pcrdt.cleanup_old_snapshots(1, false).unwrap(); // Aggressive cleanup
 
-    let final_snapshots: Vec<_> = std::fs::read_dir(&base_path)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_name().to_string_lossy().starts_with("snapshot_"))
-        .collect();
+  let final_snapshots: Vec<_> = std::fs::read_dir(&base_path)
+    .unwrap()
+    .filter_map(|e| e.ok())
+    .filter(|e| e.file_name().to_string_lossy().starts_with("snapshot_"))
+    .collect();
 
-    // Should have kept only recent snapshots (1 full + associated incrementals)
-    assert!(
-        final_snapshots.len() <= remaining.len(),
-        "Aggressive cleanup should reduce snapshot count"
-    );
+  // Should have kept only recent snapshots (1 full + associated incrementals)
+  assert!(
+    final_snapshots.len() <= remaining.len(),
+    "Aggressive cleanup should reduce snapshot count"
+  );
 
-    let _ = std::fs::remove_dir_all(&base_path);
+  let _ = std::fs::remove_dir_all(&base_path);
 }
 
 #[test]
 #[cfg(feature = "msgpack")]
 fn test_incremental_chain_validation() {
-    use crdt_lite::persist::{PersistedCRDT, PersistConfig, SnapshotFormat};
+  use crdt_lite::persist::{PersistConfig, PersistedCRDT, SnapshotFormat};
 
-    let base_path = std::env::temp_dir().join("test_chain_validation");
-    let _ = std::fs::remove_dir_all(&base_path);
-    std::fs::create_dir_all(&base_path).unwrap();
+  let base_path = std::env::temp_dir().join("test_chain_validation");
+  let _ = std::fs::remove_dir_all(&base_path);
+  std::fs::create_dir_all(&base_path).unwrap();
 
-    let config = PersistConfig {
-        snapshot_threshold: 10,
-        snapshot_format: SnapshotFormat::MessagePack,
-        enable_incremental_snapshots: true,
-        full_snapshot_interval: 5,
-        ..Default::default()
-    };
+  let config = PersistConfig {
+    snapshot_threshold: 10,
+    snapshot_format: SnapshotFormat::MessagePack,
+    enable_incremental_snapshots: true,
+    full_snapshot_interval: 5,
+    ..Default::default()
+  };
 
-    let mut pcrdt = PersistedCRDT::<String, String, String>::open(
-        base_path.clone(),
-        1,
-        config.clone(),
-    )
-    .unwrap();
+  let mut pcrdt =
+    PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config.clone()).unwrap();
 
-    // Create full snapshot + 3 incrementals
-    for i in 0..10 {
-        pcrdt.insert_or_update(
-            &format!("rec{}", i),
-            vec![("field".to_string(), format!("v0_{}", i))],
-        ).unwrap();
+  // Create full snapshot + 3 incrementals
+  for i in 0..10 {
+    pcrdt
+      .insert_or_update(
+        &format!("rec{}", i),
+        vec![("field".to_string(), format!("v0_{}", i))],
+      )
+      .unwrap();
+  }
+  pcrdt.snapshot().unwrap(); // Full #1
+
+  for round in 1..=3 {
+    for i in 0..5 {
+      pcrdt
+        .insert_or_update(
+          &format!("rec{}", i),
+          vec![("field".to_string(), format!("v{}_{}", round, i))],
+        )
+        .unwrap();
     }
-    pcrdt.snapshot().unwrap(); // Full #1
+    pcrdt.snapshot().unwrap(); // Incrementals #2, #3, #4
+  }
 
-    for round in 1..=3 {
-        for i in 0..5 {
-            pcrdt.insert_or_update(
-                &format!("rec{}", i),
-                vec![("field".to_string(), format!("v{}_{}", round, i))],
-            ).unwrap();
-        }
-        pcrdt.snapshot().unwrap(); // Incrementals #2, #3, #4
-    }
+  // Verify files exist
+  let files: Vec<_> = std::fs::read_dir(&base_path)
+    .unwrap()
+    .filter_map(|e| e.ok())
+    .filter(|e| {
+      let name = e.file_name().to_string_lossy().to_string();
+      name.starts_with("snapshot_full_") || name.starts_with("snapshot_incr_")
+    })
+    .map(|e| e.path())
+    .collect();
 
-    // Verify files exist
-    let files: Vec<_> = std::fs::read_dir(&base_path)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            let name = e.file_name().to_string_lossy().to_string();
-            name.starts_with("snapshot_full_") || name.starts_with("snapshot_incr_")
-        })
-        .map(|e| e.path())
-        .collect();
+  assert_eq!(
+    files
+      .iter()
+      .filter(|f| f.to_string_lossy().contains("full"))
+      .count(),
+    1
+  );
+  assert_eq!(
+    files
+      .iter()
+      .filter(|f| f.to_string_lossy().contains("incr"))
+      .count(),
+    3
+  );
 
-    assert_eq!(files.iter().filter(|f| f.to_string_lossy().contains("full")).count(), 1);
-    assert_eq!(files.iter().filter(|f| f.to_string_lossy().contains("incr")).count(), 3);
+  // Delete the middle incremental to create a gap
+  let mut incr_files: Vec<_> = files
+    .iter()
+    .filter(|f| f.to_string_lossy().contains("incr_"))
+    .cloned()
+    .collect();
+  incr_files.sort();
 
-    // Delete the middle incremental to create a gap
-    let mut incr_files: Vec<_> = files.iter()
-        .filter(|f| f.to_string_lossy().contains("incr_"))
-        .cloned()
-        .collect();
-    incr_files.sort();
+  // Delete the middle one (index 1 of 3)
+  if incr_files.len() == 3 {
+    std::fs::remove_file(&incr_files[1]).unwrap();
+  }
 
-    // Delete the middle one (index 1 of 3)
-    if incr_files.len() == 3 {
-        std::fs::remove_file(&incr_files[1]).unwrap();
-    }
+  // Recover - should warn about non-contiguous incrementals
+  // Capture stderr to verify warning (in real code, warnings go to eprintln!)
+  let result = PersistedCRDT::<String, String, String>::open(base_path.clone(), 1, config);
 
-    // Recover - should warn about non-contiguous incrementals
-    // Capture stderr to verify warning (in real code, warnings go to eprintln!)
-    let result = PersistedCRDT::<String, String, String>::open(
-        base_path.clone(),
-        1,
-        config,
-    );
+  // Recovery should succeed (warnings are non-fatal)
+  assert!(result.is_ok(), "Recovery should succeed despite gap");
 
-    // Recovery should succeed (warnings are non-fatal)
-    assert!(result.is_ok(), "Recovery should succeed despite gap");
+  // Note: The warning about gap will be printed to stderr but won't fail the test
+  // In a real scenario, monitoring systems would catch these warnings
 
-    // Note: The warning about gap will be printed to stderr but won't fail the test
-    // In a real scenario, monitoring systems would catch these warnings
-
-    let _ = std::fs::remove_dir_all(&base_path);
+  let _ = std::fs::remove_dir_all(&base_path);
 }


### PR DESCRIPTION
Implements a disk-streaming CRDT that supports datasets larger than memory by:

- Loading records on-demand from indexed snapshots
- Keeping recent changes in a hot in-memory tier
- Using an LRU cache for frequently accessed cold records
- Migrating automatically from existing MessagePack snapshots

New indexed snapshot format stores:
- Header with metadata and offsets
- Records section (MessagePack, seekable)
- Tombstones section (loaded at startup)
- Index section (key -> offset mapping)

Key features:
- Fast startup: only loads index + tombstones, not all records
- Low memory: configurable LRU cache size (default 1000 records)
- Seamless API: same interface as PersistedCRDT
- Auto-migration: converts existing snapshots to indexed format